### PR TITLE
Revert repoze.who for ckanext-saml2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ Update dependencies.
 
     $ make update-dependencies
 
-Update lock file for dependencies.
+Update lock file for dependencies. **Because of a version conflict for
+repoze.who, special care should be taken to make sure that repoze.who==1.0.18 is
+shipped to production in order to be compatible with ckanext-saml2. After
+generating the requirements-freeze.txt, manually review the file to make sure
+the versions are correct. See https://github.com/GSA/catalog-app/issues/78 for
+more details.**
 
     $ make requirements
+
 
 ### Live Editing
 

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -50,7 +50,7 @@ pyutilib.component.core==4.5.3
 PyYAML==5.1.2
 redis==2.10.1
 repoze.lru==0.6
-repoze.who==2.0
+repoze.who==1.0.18
 repoze.who-friendlyform==1.0.8
 requests==2.20.0
 rfc3987==1.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,9 @@ pytz
 tzlocal~=1.0
 Markdown~=2.6.11
 repoze.lru==0.6
-repoze.who==2.0
+# CKAN requires 2.0 but ckanext-saml2 requires 1.0.18
+# https://github.com/GSA/catalog-app/issues/78
+repoze.who==1.0.18
 repoze.who-friendlyform==1.0.8
 simplejson==3.3.1
 six==1.7.3

--- a/start.sh
+++ b/start.sh
@@ -40,5 +40,8 @@ fi
 # Run migrations
 paster --plugin=ckan db upgrade -c /etc/ckan/production.ini
 
+# Work around https://github.com/GSA/catalog-app/issues/78
+pip install -U repoze.who==2.0
+
 echo starting ckan...
 exec paster --plugin=ckan serve /etc/ckan/production.ini


### PR DESCRIPTION
So because of a [version conflict](https://github.com/GSA/catalog-app/issues/78), we don't have a single set of dependencies that work for development and production for Inventory. For production, we use saml2 authentication with max.gov which requires repoze.who==1.0.18 and for local development we need user/pass authentication and repoze.who==2.0.

In catalog-app, we basically work around this by installing repoze.who==2.0 for develop, anad repoze.who==1.0.18 for staging/production.

The better fix would be to get off our forks for pysaml2 and ckanext-saml2 and make sure they work with recent versions of repose.who https://github.com/GSA/datagov-deploy/issues/414.

Or, maybe we try to get saml2 working in local develop, but that feels like another work around.