### PR TITLE
All dependencies bumped except for SQLAlchemy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN /usr/local/bin/pip install -U pip && \
 
 # Create ckan virtualenv
 RUN mkdir -p $CKAN_HOME && \
-  virtualenv $CKAN_HOME --no-site-packages -p /usr/local/bin/python
+  virtualenv $CKAN_HOME -p /usr/local/bin/python
 
 COPY requirements.txt /tmp/
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: up
 build:
 	docker-compose build
 
-down:
+clean:
 	docker-compose down -v
 
 requirements:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ all: up
 build:
 	docker-compose build
 
+down:
+	docker-compose down -v
+
 requirements:
 	docker-compose run --rm -T app pip --quiet freeze > requirements-freeze.txt
 
@@ -16,7 +19,8 @@ up:
 	docker-compose up
 
 up-with-data:
-	docker-compose up -f docker-compose.yml -f docker-compose.seed.yml
+	docker-compose -f docker-compose.yml -f docker-compose.seed.yml build
+	docker-compose -f docker-compose.yml -f docker-compose.seed.yml up
 
 update-dependencies:
 	docker-compose run --rm app pip install -r requirements.txt

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,10 +1,10 @@
 Babel==0.9.6
 Beaker==1.6.4
-bleach==1.5.0
-certifi==2019.9.11
-cffi==1.13.1
+bleach==2.1.2
+certifi==2019.11.28
+cffi==1.13.2
 chardet==3.0.4
--e git+https://github.com/GSA/ckan.git@c4ec614b49705860b05fa7d0e10c0ce7675e785e#egg=ckan
+-e git+https://github.com/GSA/ckan.git@3e96d7f2a24d136fb2cfe60a51720e043f21369e#egg=ckan
 -e git+https://github.com/GSA/ckanext-datajson.git@177c9d8719964feed341541aae9a4d1009944be5#egg=ckanext_datajson
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@0b90194d77938e59ecb7d6937c201bd6815447f8#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/ckan/ckanext-harvest.git@13dbb1eea428e6b274f98c36bf29d42e62a70af7#egg=ckanext_harvest
@@ -17,11 +17,11 @@ enum34==1.1.6
 fanstatic==0.12
 FormEncode==1.2.6
 Genshi==0.6
-html5lib==0.9999999
-httplib2==0.14.0
+html5lib=1.0.1
+httplib2==0.16.0
 idna==2.7
 ipaddress==1.0.23
-Jinja2==2.6
+Jinja2==2.10.3
 jsonschema==2.4.0
 LEPL==5.1.3
 M2Crypto==0.23.0
@@ -39,7 +39,7 @@ pbr==0.8.2
 pika==0.9.8
 psycopg2==2.4.5
 pycparser==2.19
-Pygments==1.6
+Pygments==2.5.2
 Pylons==0.9.7
 pyOpenSSL==18.0.0
 -e git+https://github.com/GSA/pysaml2.git@8b605c824ff1d042e9040a9971c28f369197cac2#egg=pysaml2
@@ -47,7 +47,7 @@ python-dateutil==1.5
 python-memcached==1.48
 pytz==2019.3
 pyutilib.component.core==4.5.3
-PyYAML==5.1.2
+PyYAML==5.3
 redis==2.10.1
 repoze.lru==0.6
 repoze.who==1.0.18
@@ -56,7 +56,7 @@ requests==2.20.0
 rfc3987==1.3.8
 Routes==1.13
 simplejson==3.3.1
-six==1.7.3
+six==1.14.0
 solrpy==0.9.5
 SQLAlchemy==0.9.6
 sqlalchemy-migrate==0.9.1
@@ -66,8 +66,9 @@ tzlocal==1.5.1
 unicodecsv==0.9.4
 urllib3==1.24.3
 vdm==0.13
+webencodings==0.5.1
 WebError==0.10.3
 WebHelpers==1.3
-WebOb==1.0.8
+WebOb==1.6.4
 WebTest==1.4.3
 zope.interface==4.1.1

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -50,7 +50,7 @@ pyutilib.component.core==4.5.3
 PyYAML==5.3
 redis==2.10.1
 repoze.lru==0.6
-repoze.who==2.0
+repoze.who==1.0.18
 repoze.who-friendlyform==1.0.8
 requests==2.20.0
 rfc3987==1.3.8

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -2,7 +2,7 @@ Babel==0.9.6
 Beaker==1.6.4
 bleach==2.1.2
 certifi==2019.11.28
-cffi==1.13.2
+cffi==1.14.0
 chardet==3.0.4
 -e git+https://github.com/GSA/ckan.git@3e96d7f2a24d136fb2cfe60a51720e043f21369e#egg=ckan
 -e git+https://github.com/GSA/ckanext-datajson.git@177c9d8719964feed341541aae9a4d1009944be5#egg=ckanext_datajson
@@ -17,8 +17,8 @@ enum34==1.1.6
 fanstatic==0.12
 FormEncode==1.2.6
 Genshi==0.6
-html5lib=1.0.1
-httplib2==0.16.0
+html5lib==1.0.1
+httplib2==0.17.0
 idna==2.7
 ipaddress==1.0.23
 Jinja2==2.10.3
@@ -50,7 +50,7 @@ pyutilib.component.core==4.5.3
 PyYAML==5.3
 redis==2.10.1
 repoze.lru==0.6
-repoze.who==1.0.18
+repoze.who==2.0
 repoze.who-friendlyform==1.0.8
 requests==2.20.0
 rfc3987==1.3.8
@@ -69,6 +69,6 @@ vdm==0.13
 webencodings==0.5.1
 WebError==0.10.3
 WebHelpers==1.3
-WebOb==1.0.8
+-e git+https://github.com/GSA/webob.git@90d895f9a85c8bea11c80efa4e2f6bdd04eabbe4#egg=WebOb
 WebTest==1.4.3
 zope.interface==4.1.1

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -69,6 +69,6 @@ vdm==0.13
 webencodings==0.5.1
 WebError==0.10.3
 WebHelpers==1.3
-WebOb==1.6.4
+WebOb==1.0.8
 WebTest==1.4.3
 zope.interface==4.1.1

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,11 +1,11 @@
 Babel==0.9.6
 Beaker==1.6.4
-bleach==2.1.2
+bleach==2.1.3
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 -e git+https://github.com/GSA/ckan.git@3e96d7f2a24d136fb2cfe60a51720e043f21369e#egg=ckan
--e git+https://github.com/GSA/ckanext-datajson.git@177c9d8719964feed341541aae9a4d1009944be5#egg=ckanext_datajson
+-e git+https://github.com/GSA/ckanext-datajson.git@0a3007a847d75d37e8c0130bada5bc4af7351d7b#egg=ckanext_datajson
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@0b90194d77938e59ecb7d6937c201bd6815447f8#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/ckan/ckanext-harvest.git@13dbb1eea428e6b274f98c36bf29d42e62a70af7#egg=ckanext_harvest
 -e git+https://github.com/GSA/ckanext-saml2.git@0e1f11cb3b211e6d337b86ffe7c07620821f7d7d#egg=ckanext_saml2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@
 -e git+https://github.com/GSA/ckanext-saml2.git@max#egg=ckanext-saml2
 -e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob
 Pylons==0.9.7
-# WebOb==1.0.8
-# WebOb==1.8.6
 
 # ckan dependencies
 Babel==0.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Pylons==0.9.7
 # ckan dependencies
 Babel==0.9.6
 Beaker==1.6.4
-bleach==2.1.2
+bleach==2.1.3
 FormEncode==1.2.6
 Genshi==0.6
 Jinja2~=2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@
 -e git+https://github.com/GSA/USMetadata.git@master#egg=ckanext-usmetadata
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@master#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-saml2.git@max#egg=ckanext-saml2
+-e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob
+Pylons==0.9.7
+# WebOb==1.0.8
+# WebOb==1.8.6
 
 # ckan dependencies
 Babel==0.9.6
@@ -19,13 +23,13 @@ Paste==1.7.5.1
 PasteDeploy==1.5.0
 PasteScript==1.7.5
 Pygments==2.5.2
-Pylons==0.9.7
+
 Routes==1.13
 SQLAlchemy==0.9.6
 Tempita==0.5.2
 WebError==0.10.3
 WebHelpers==1.3
-WebOb==1.0.8
+
 WebTest==1.4.3
 argparse==1.2.1
 decorator==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ SQLAlchemy==0.9.6
 Tempita==0.5.2
 WebError==0.10.3
 WebHelpers==1.3
-WebOb~=1.6.0
+WebOb==1.0.8
 WebTest==1.4.3
 argparse==1.2.1
 decorator==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/GSA/ckan.git@inventory#egg=ckan
+-e git+https://github.com/GSA/ckan.git@inventory-bump-dependencies#egg=ckan
 -e git+https://github.com/ckan/ckanext-harvest.git@13dbb1eea428e6b274f98c36bf29d42e62a70af7#egg=ckanext-harvest
 -e git+https://github.com/GSA/ckanext-datajson.git@master#egg=ckanext-datajson
 -e git+https://github.com/GSA/USMetadata.git@master#egg=ckanext-usmetadata
@@ -8,24 +8,24 @@
 # ckan dependencies
 Babel==0.9.6
 Beaker==1.6.4
-bleach~=1.5.0
+bleach==2.1.2
 FormEncode==1.2.6
 Genshi==0.6
-Jinja2==2.6
+Jinja2~=2.10.1
 Mako==0.9.0
 MarkupSafe==0.18
 Pairtree==0.7.1-T
 Paste==1.7.5.1
 PasteDeploy==1.5.0
 PasteScript==1.7.5
-Pygments==1.6
+Pygments==2.5.2
 Pylons==0.9.7
 Routes==1.13
 SQLAlchemy==0.9.6
 Tempita==0.5.2
 WebError==0.10.3
 WebHelpers==1.3
-WebOb==1.0.8
+WebOb~=1.6.0
 WebTest==1.4.3
 argparse==1.2.1
 decorator==3.4.0
@@ -46,7 +46,7 @@ repoze.lru==0.6
 repoze.who==1.0.18
 repoze.who-friendlyform==1.0.8
 simplejson==3.3.1
-six==1.7.3
+six~=1.9
 solrpy==0.9.5
 sqlalchemy-migrate==0.9.1
 sqlparse==0.1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/GSA/ckan.git@inventory-bump-dependencies#egg=ckan
+-e git+https://github.com/GSA/ckan.git@inventory#egg=ckan
 -e git+https://github.com/ckan/ckanext-harvest.git@13dbb1eea428e6b274f98c36bf29d42e62a70af7#egg=ckanext-harvest
 -e git+https://github.com/GSA/ckanext-datajson.git@master#egg=ckanext-datajson
 -e git+https://github.com/GSA/USMetadata.git@master#egg=ckanext-usmetadata

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -48,3 +48,7 @@ function test_login_and_datasets () {
   # Validate output is 22, curl response for 403 (Forbidden)
   [ "$status" -eq 22 ]
 }
+
+@test "Website display is working" {
+  curl --silent --fail http://app:5000/dataset/test-dataset-1 --cookie ./cookie-jar
+}


### PR DESCRIPTION
Validated locally individually and against make test. All tested features working as expected. 
All risks noted from Snyk scan are within required ranges except for SQLAlchemy, will be handled in a separate PR. Library bumps include

 - Jinja2
 - Pygments
 - bleach
 - html5lib
 - webob (via fork and manual patch)