### PR TITLE
Some tweaks to the cloud.gov work

### DIFF
--- a/datastore-usersetup.py
+++ b/datastore-usersetup.py
@@ -4,18 +4,77 @@
 
 import os
 import psycopg2
+import re
 import sys
+from urlparse import urlparse
 
-try:
-    conn=psycopg2.connect(os.environ['DATASTORE_URL'])
-except:
-    print "Unable to connect to datastore"
-    sys.exit(-1)
+def squote(s):
+    """
+    Return s as a single-quoted quoted string
+    """
+    return u"'" + s.replace(u"'", u"''").replace(u'\0', '') + u"'"
 
-cur = conn.cursor()
-try:
-    cur.execute('CREATE USER ' + os.environ['DS_RO_USER'] + ' WITH NOCREATEUSER NOCREATEDB ENCRYPTED PASSWORD ' + os.environ['DS_RO_PASSWORD'])
-    cur.execute(os.environ['DS_PERMS_SQL'])
-except:
-    print "Got exception setting up user; likely already exists"
+def identifier(s):
+    """
+    Return s as a double-quoted string (good for psql identifiers)
+    """
+    return u'"' + s.replace(u'"', u'""').replace(u'\0', '') + u'"'
 
+def datastore_sql(datastoredb, writeuser, readuser, readpassword):
+    """
+    Return some SQL to create and permission the datastore
+    readonly user.
+    """
+    
+    template_filename = 'set_permissions.sql'
+
+    with open(template_filename) as fp:
+        template = fp.read()
+
+    return template.format(
+        datastoredb=identifier(datastoredb),
+        writeuser=identifier(writeuser),
+        readuser=identifier(readuser),
+        readpassword=squote(readpassword))
+
+def get_env(name):
+    if name not in os.environ:
+        raise Exception("Required environment variable %s is missing" % name)
+    value = os.environ[name]
+    if not value:
+        raise Exception("Environment variable %s missing value" % name)
+    return value
+
+def main():
+    datastore_url = get_env('DATASTORE_URL')
+    readuser = get_env('DS_RO_USER')
+    readpassword = get_env('DS_RO_PASSWORD')
+
+    datastore = urlparse(get_env('DATASTORE_URL'))
+    datastoredb = datastore.path.lstrip('/')
+    writeuser = datastore.username
+
+    if not datastoredb:
+        raise Exception("DATASTORE_URL is missing the database")
+    if not writeuser:
+        raise Exception("DATASTORE_URL is missing a user name")
+    
+    sql = datastore_sql(datastoredb, writeuser, readuser, readpassword)
+
+    print "<datastore SQL>"
+    print sql
+    print "</datastore SQL>"
+
+    try:
+        with psycopg2.connect(datastore_url) as conn:
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(sql)
+            except Exception as sql_e:
+                print "Exception while executing SQL:", str(sql_e)
+    except Exception as conn_e:
+        print "Unable to connect to datastore:", str(conn_e)
+        sys.exit(-1)
+
+if __name__ == '__main__':
+    main()

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,8 @@ applications:
     routes:
     - route: ((app_name))-solr.apps.internal
   - name: ((app_name))
+    buildpacks:
+      - https://github.com/cloudfoundry/python-buildpack#v1.7.6
     random-route: true
     services:
     - ((app_name))-db        # cf create-service aws-rds shared-psql ((app_name))-db
@@ -14,4 +16,4 @@ applications:
     env:
       DS_RO_USER: datastore_default
       DS_RO_PASSWORD: ((datastore_readonly_password))
-      SOLR_URL: ((app_name))-solr.apps.internal:8983/solr/ckan2_5
+      SOLR_URL: http://((app_name))-solr.apps.internal:8983/solr/ckan2_5

--- a/set_permissions.sql
+++ b/set_permissions.sql
@@ -1,0 +1,50 @@
+/*
+This script configures the permissions for the datastore.
+
+It ensures that the datastore read-only user will only be able to select from
+the datastore database but has no create/write/edit permission or any
+permissions on other databases. You must execute this script as a database
+superuser on the PostgreSQL server that hosts your datastore database.
+
+For example, if PostgreSQL is running locally and the "postgres" user has the
+appropriate permissions (as in the default Ubuntu PostgreSQL install), you can
+run:
+
+    paster datastore set-permissions | sudo -u postgres psql
+
+Or, if your PostgreSQL server is remote, you can pipe the permissions script
+over SSH:
+
+    paster datastore set-permissions | ssh dbserver sudo -u postgres psql
+
+*/
+
+-- create the read-only user
+
+DO $$
+BEGIN
+    CREATE USER {readuser} WITH ENCRYPTED PASSWORD {readpassword};
+    EXCEPTION WHEN DUPLICATE_OBJECT THEN
+    RAISE NOTICE 'Role already exists; skipping creation';
+END
+$$;
+
+-- revoke permissions for the read-only user
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+
+GRANT CREATE ON SCHEMA public TO {writeuser};
+GRANT USAGE ON SCHEMA public TO {writeuser};
+
+-- grant select permissions for read-only user
+GRANT CONNECT ON DATABASE {datastoredb} TO {readuser};
+GRANT USAGE ON SCHEMA public TO {readuser};
+
+-- grant access to current tables and views to read-only user
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO {readuser};
+
+-- grant access to new tables and views by default
+ALTER DEFAULT PRIVILEGES FOR USER {writeuser} IN SCHEMA public
+   GRANT SELECT ON TABLES TO {readuser};
+
+


### PR DESCRIPTION
- Pin buildpack to a version that includes Python 2.x
- "Harden" datastore ro user creation and permissioning
- Remove a few instances of hardwired service names
- Fix a SOLR URL