### PR TITLE
Recent changes in dcat_usmetadata

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -6,7 +6,7 @@ cffi==1.14.2
 chardet==3.0.4
 -e git+https://github.com/GSA/ckan.git@3d540085eeae52261bef37450c7fc7bcd927d658#egg=ckan
 -e git+https://github.com/GSA/ckanext-datajson.git@214ec53c9071d18bc7f7a241a28f6d7f0038276e#egg=ckanext_datajson
--e git+https://github.com/GSA/ckanext-dcat_usmetadata.git@b882e9418d6912e55b97ae85d45c4f0dc5dd434d#egg=ckanext_dcat_usmetadata
+-e git+https://github.com/GSA/ckanext-dcat_usmetadata.git@4924321ed66b03e949ed46ccd7831f7de06c8c62#egg=ckanext_dcat_usmetadata
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic.git@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/ckan/ckanext-harvest.git@13dbb1eea428e6b274f98c36bf29d42e62a70af7#egg=ckanext_harvest
 -e git+https://github.com/GSA/ckanext-saml2.git@0e1f11cb3b211e6d337b86ffe7c07620821f7d7d#egg=ckanext_saml2


### PR DESCRIPTION
- API URL in the template and empty resource fixes
- Remove Meets Agency Data Quality field
- Tags field is now required
- [required][m] Update field lable names + defaults