### PR TITLE
update-dependencies

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,14 +1,14 @@
 Babel==2.3.4
 Beaker==1.9.0
 bleach==3.1.4
-certifi==2020.6.20
+certifi==2020.11.8
 chardet==3.0.4
 -e git+https://github.com/ckan/ckan.git@c04b6d64aadc7a647b8896279002626ca3be0a56#egg=ckan
--e git+https://github.com/GSA/ckanext-datajson.git@2de35359d3a996cb8d463cdfb2935f3e0a94ca6f#egg=ckanext_datajson
+-e git+https://github.com/GSA/ckanext-datajson.git@a66f314333862bc316086a25e735f472cb5b29fe#egg=ckanext_datajson
 ckanext-dcat-usmetadata==0.1.11
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-saml2.git@0e1f11cb3b211e6d337b86ffe7c07620821f7d7d#egg=ckanext_saml2
--e git+https://github.com/GSA/USMetadata.git@5a5d5e04d7c83b65f222298635faf4d22ee063e6#egg=ckanext_usmetadata
+-e git+https://github.com/GSA/USMetadata.git@e5cf4ffc4f504f13b6c2034bd13759714eb48f95#egg=ckanext_usmetadata
 click==6.7
 decorator==4.2.1
 fanstatic==0.12


### PR DESCRIPTION
usmetadata has two commits mentioned in [this ticket](https://github.com/GSA/datagov-deploy/issues/2395) that should help with the image bugs