### PR TITLE
Enable saml2 for login.gov

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 ckanext-dcat-usmetadata==0.2.4
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-s3filestore@3fe563120c914627610fdf5df48eb6b42bd3c284#egg=ckanext_s3filestore
--e git+https://github.com/GSA/ckanext-saml2.git@0e1f11cb3b211e6d337b86ffe7c07620821f7d7d#egg=ckanext_saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@063935d1836eaeebf4b00305c9e13ce27cf0ea66#egg=ckanext_saml2
 -e git+https://github.com/GSA/USMetadata.git@a6aab9f54fc1a55b8f668dfa0d74e981a3a0df66#egg=ckanext_usmetadata
 ckantoolkit==0.0.4
 click==6.7
@@ -51,7 +51,7 @@ polib==1.0.7
 psycopg2==2.7.3.2
 Pygments==2.2.0
 Pylons==0.9.7
--e git+https://github.com/GSA/pysaml2.git@8b605c824ff1d042e9040a9971c28f369197cac2#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@51b7e09d0f6d3af31c9d60b09a3f335eb6ecfa5c#egg=pysaml2
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 ckanext-dcat-usmetadata==0.2.4
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-s3filestore@3fe563120c914627610fdf5df48eb6b42bd3c284#egg=ckanext_s3filestore
--e git+https://github.com/GSA/ckanext-saml2.git@063935d1836eaeebf4b00305c9e13ce27cf0ea66#egg=ckanext_saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@07df14dba0d42c83cd6cdd95a16279198a8d5349#egg=ckanext_saml2
 -e git+https://github.com/GSA/USMetadata.git@a6aab9f54fc1a55b8f668dfa0d74e981a3a0df66#egg=ckanext_usmetadata
 ckantoolkit==0.0.4
 click==6.7
@@ -52,7 +52,7 @@ polib==1.0.7
 psycopg2==2.7.3.2
 Pygments==2.2.0
 Pylons==0.9.7
--e git+https://github.com/GSA/pysaml2.git@51b7e09d0f6d3af31c9d60b09a3f335eb6ecfa5c#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@1f876cb6936d9dd6bd798ce83f5a61ce77274e56#egg=pysaml2
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 ckanext-dcat-usmetadata==0.2.4
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-s3filestore@3fe563120c914627610fdf5df48eb6b42bd3c284#egg=ckanext_s3filestore
--e git+https://github.com/GSA/ckanext-saml2.git@07df14dba0d42c83cd6cdd95a16279198a8d5349#egg=ckanext_saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@063935d1836eaeebf4b00305c9e13ce27cf0ea66#egg=ckanext_saml2
 -e git+https://github.com/GSA/USMetadata.git@a6aab9f54fc1a55b8f668dfa0d74e981a3a0df66#egg=ckanext_usmetadata
 ckantoolkit==0.0.4
 click==6.7
@@ -52,7 +52,7 @@ polib==1.0.7
 psycopg2==2.7.3.2
 Pygments==2.2.0
 Pylons==0.9.7
--e git+https://github.com/GSA/pysaml2.git@1f876cb6936d9dd6bd798ce83f5a61ce77274e56#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@51b7e09d0f6d3af31c9d60b09a3f335eb6ecfa5c#egg=pysaml2
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 ckanext-dcat-usmetadata==0.2.4
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-s3filestore@3fe563120c914627610fdf5df48eb6b42bd3c284#egg=ckanext_s3filestore
--e git+https://github.com/GSA/ckanext-saml2.git@063935d1836eaeebf4b00305c9e13ce27cf0ea66#egg=ckanext_saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@07df14dba0d42c83cd6cdd95a16279198a8d5349#egg=ckanext_saml2
 -e git+https://github.com/GSA/USMetadata.git@a6aab9f54fc1a55b8f668dfa0d74e981a3a0df66#egg=ckanext_usmetadata
 ckantoolkit==0.0.4
 click==6.7
@@ -52,7 +52,7 @@ polib==1.0.7
 psycopg2==2.7.3.2
 Pygments==2.2.0
 Pylons==0.9.7
--e git+https://github.com/GSA/pysaml2.git@51b7e09d0f6d3af31c9d60b09a3f335eb6ecfa5c#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@08883cda0a8c0743b8a9cfa6ec176ddf9b9e7a56#egg=pysaml2
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 ckanext-dcat-usmetadata==0.2.4
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@54647da628609543e01731bfc37f0c3d0ad9f0e2#egg=ckanext_googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-s3filestore@3fe563120c914627610fdf5df48eb6b42bd3c284#egg=ckanext_s3filestore
--e git+https://github.com/GSA/ckanext-saml2.git@07df14dba0d42c83cd6cdd95a16279198a8d5349#egg=ckanext_saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@3a1145ba5c71433cff488707d47d41ae2941e040#egg=ckanext_saml2
 -e git+https://github.com/GSA/USMetadata.git@a6aab9f54fc1a55b8f668dfa0d74e981a3a0df66#egg=ckanext_usmetadata
 ckantoolkit==0.0.4
 click==6.7
@@ -52,7 +52,7 @@ polib==1.0.7
 psycopg2==2.7.3.2
 Pygments==2.2.0
 Pylons==0.9.7
--e git+https://github.com/GSA/pysaml2.git@08883cda0a8c0743b8a9cfa6ec176ddf9b9e7a56#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@45d0ea01b3e3c1fba2757387f8068d57153ce2ce#egg=pysaml2
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -16,6 +16,7 @@ ckanext-dcat-usmetadata==0.2.4
 ckantoolkit==0.0.4
 click==6.7
 decorator==4.2.1
+defusedxml==0.6.0
 fanstatic==0.12
 Flask==0.12.4
 Flask-Babel==0.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/USMetadata.git@ckan-2-8#egg=ckanext-usmetadata
 -e git+https://github.com/GSA/ckanext-datajson.git@master#egg=ckanext-datajson
--e git+https://github.com/GSA/ckanext-saml2.git@max#egg=ckanext-saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@063935d1836eaeebf4b00305c9e13ce27cf0ea66#egg=ckanext-saml2
 -e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob
 ckanext-dcat-usmetadata~=0.2
 -e git+https://github.com/GSA/ckanext-s3filestore@datagov-v0.1.1#egg=ckanext-s3filestore
@@ -75,8 +75,10 @@ Werkzeug==0.15.3         # via flask
 zope.interface==4.3.2
 
 # ckanext-saml2 dependencies
+defusedxml==0.6.0
 M2Crypto
--e git+https://github.com/GSA/pysaml2.git@max#egg=pysaml2
+python-memcached==1.48
+-e git+https://github.com/GSA/pysaml2.git@51b7e09d0f6d3af31c9d60b09a3f335eb6ecfa5c#egg=pysaml2
 
 #datajson
 jsonschema~=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/USMetadata.git@ckan-2-8#egg=ckanext-usmetadata
 -e git+https://github.com/GSA/ckanext-datajson.git@master#egg=ckanext-datajson
--e git+https://github.com/GSA/ckanext-saml2.git@063935d1836eaeebf4b00305c9e13ce27cf0ea66#egg=ckanext-saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@datagov-0.4.0-config#egg=ckanext-saml2
 -e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob
 ckanext-dcat-usmetadata~=0.2
 -e git+https://github.com/GSA/ckanext-s3filestore@datagov-v0.1.1#egg=ckanext-s3filestore
@@ -78,7 +78,7 @@ zope.interface==4.3.2
 defusedxml==0.6.0
 M2Crypto
 python-memcached==1.48
--e git+https://github.com/GSA/pysaml2.git@51b7e09d0f6d3af31c9d60b09a3f335eb6ecfa5c#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@feature/ci-login-gov#egg=pysaml2
 
 #datajson
 jsonschema~=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/USMetadata.git@ckan-2-8#egg=ckanext-usmetadata
 -e git+https://github.com/GSA/ckanext-datajson.git@master#egg=ckanext-datajson
--e git+https://github.com/GSA/ckanext-saml2.git@datagov-0.4.0-config#egg=ckanext-saml2
+-e git+https://github.com/GSA/ckanext-saml2.git@datagov/v0.4.0#egg=ckanext-saml2
 -e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob
 ckanext-dcat-usmetadata~=0.2
 -e git+https://github.com/GSA/ckanext-s3filestore@datagov-v0.1.1#egg=ckanext-s3filestore
@@ -78,7 +78,7 @@ zope.interface==4.3.2
 defusedxml==0.6.0
 M2Crypto
 python-memcached==1.48
--e git+https://github.com/GSA/pysaml2.git@feature/ci-login-gov#egg=pysaml2
+-e git+https://github.com/GSA/pysaml2.git@datagov/v4.9.0#egg=pysaml2
 
 #datajson
 jsonschema~=2.4.0


### PR DESCRIPTION
Install the necessary components for login.gov pysaml configuration, but leave off usage (to be utilized/configured by environment).