### PR TITLE
Prevent build error from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python
+    steps:
+      - run:
+          name: N/A
+          command: |
+            echo See GitHub actions for CI.
+            echo ok


### PR DESCRIPTION
We switched to GH actions but still use CircleCI for building the `fcs` branch.
Keep a dummy config here to avoid our PRs marked with a build error.