### PR TITLE
Create issue on deployment failure

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -58,8 +58,8 @@ jobs:
               q: "inventory-app+in:title+type:issue+repo:gsa/datagov-deploy",
 
             }))
-            if(current_issues) {
-              console.log(current_issues);
+            if(current_issues.data.items.length > 0) {
+              console.log(current_issues.data.items);
             } else {
               console.log("No matches");
             }

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -44,6 +44,26 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: deployment failed
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GH_DATAGOV_TOKEN}}
+          script: |
+            const issue_title = `Deploy error on ${context.payload.repository.name}`
+            const base_github_options = {
+              owner: context.repo.owner,
+              repo: 'datagov-deploy'
+            }
+            const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
+              q: issue_title + "+in:title+type:issue+repo:gsa/datagov-deploy",
+
+            }))
+            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
+            if(current_issues.length > 1) {
+              console.log(current_issues);
+            } else {
+              console.log("No matches");
+            }
       - name: vendor dependencies
         run: ./vendor-requirements.sh
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -58,7 +58,6 @@ jobs:
               q: issue_title + "+in:title+type:issue+repo:gsa/datagov-deploy",
 
             }))
-            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
             if(current_issues.length > 1) {
               console.log(current_issues);
             } else {

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -78,6 +78,30 @@ jobs:
           password: ${{secrets.CF_SERVICE_AUTH}}
       - name: smoke test
         run: curl --fail --silent https://inventory-dev-datagov.app.cloud.gov/api/action/status_show?$(date +%s)
+      - name: deployment failed
+        if: ${{ failure() }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GH_DATAGOV_TOKEN}}
+          script: |
+            const issue_title = `Deploy error on ${context.payload.repository.name}`
+            const base_github_options = {
+              owner: context.repo.owner,
+              repo: 'datagov-deploy'
+            }
+            const current_issues = await github.issues.listForRepo(Object.assign(base_github_options, {state: 'open'}))
+            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
+            if(current_issue) {
+              github.issues.createComment(Object.assign(base_github_options, {
+                issue_number: current_issue.number,
+                body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
+              }));
+            } else {
+              github.issues.create(Object.assign(base_github_options, {
+                title: issue_title,
+                body: `The deployment failed, please review the [job](${context.payload.repository.url}/actions/runs/${context.runId})`,
+              }));
+            }
 
   deploy-staging:
     if: github.ref == 'refs/heads/main'
@@ -104,6 +128,30 @@ jobs:
           password: ${{secrets.CF_SERVICE_AUTH}}
       - name: smoke test
         run: curl --fail --silent https://inventory-stage-datagov.app.cloud.gov/api/action/status_show?$(date +%s)
+      - name: deployment failed
+        if: ${{ failure() }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GH_DATAGOV_TOKEN}}
+          script: |
+            const issue_title = `Deploy error on ${context.payload.repository.name}`
+            const base_github_options = {
+              owner: context.repo.owner,
+              repo: 'datagov-deploy'
+            }
+            const current_issues = await github.issues.listForRepo(Object.assign(base_github_options, {state: 'open'}))
+            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
+            if(current_issue) {
+              github.issues.createComment(Object.assign(base_github_options, {
+                issue_number: current_issue.number,
+                body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
+              }));
+            } else {
+              github.issues.create(Object.assign(base_github_options, {
+                title: issue_title,
+                body: `The deployment failed, please review the [job](${context.payload.repository.url}/actions/runs/${context.runId})`,
+              }));
+            }
 
   deploy-production:
     if: github.ref == 'refs/heads/main'
@@ -128,3 +176,27 @@ jobs:
           password: ${{secrets.CF_SERVICE_AUTH}}
       - name: smoke test
         run: curl --fail --silent https://inventory-prod-datagov.app.cloud.gov/api/action/status_show?$(date +%s)
+      - name: deployment failed
+        if: ${{ failure() }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GH_DATAGOV_TOKEN}}
+          script: |
+            const issue_title = `Deploy error on ${context.payload.repository.name}`
+            const base_github_options = {
+              owner: context.repo.owner,
+              repo: 'datagov-deploy'
+            }
+            const current_issues = await github.issues.listForRepo(Object.assign(base_github_options, {state: 'open'}))
+            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
+            if(current_issue) {
+              github.issues.createComment(Object.assign(base_github_options, {
+                issue_number: current_issue.number,
+                body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
+              }));
+            } else {
+              github.issues.create(Object.assign(base_github_options, {
+                title: issue_title,
+                body: `The deployment failed, please review the [job](${context.payload.repository.url}/actions/runs/${context.runId})`,
+              }));
+            }

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -95,12 +95,12 @@ jobs:
               q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
             }))
             if(current_issues.data.items.length > 0) {
-              github.issues.createComment(Object.assign(base_github_options, {
+              github.issues.createComment(Object.assign({}, base_github_options, {
                 issue_number: current_issues.data.items[0].number,
                 body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
               }));
             } else {
-              github.issues.create(Object.assign(base_github_options, {
+              github.issues.create(Object.assign({}, base_github_options, {
                 title: issue_title,
                 body: `The deployment failed, please review the [job](${context.payload.repository.url}/actions/runs/${context.runId})`,
               }));
@@ -148,12 +148,12 @@ jobs:
               q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
             }))
             if(current_issues.data.items.length > 0) {
-              github.issues.createComment(Object.assign(base_github_options, {
+              github.issues.createComment(Object.assign({}, base_github_options, {
                 issue_number: current_issues.data.items[0].number,
                 body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
               }));
             } else {
-              github.issues.create(Object.assign(base_github_options, {
+              github.issues.create(Object.assign({}, base_github_options, {
                 title: issue_title,
                 body: `The deployment failed, please review the [job](${context.payload.repository.url}/actions/runs/${context.runId})`,
               }));
@@ -199,12 +199,12 @@ jobs:
               q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
             }))
             if(current_issues.data.items.length > 0) {
-              github.issues.createComment(Object.assign(base_github_options, {
+              github.issues.createComment(Object.assign({}, base_github_options, {
                 issue_number: current_issues.data.items[0].number,
                 body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
               }));
             } else {
-              github.issues.create(Object.assign(base_github_options, {
+              github.issues.create(Object.assign({}, base_github_options, {
                 title: issue_title,
                 body: `The deployment failed, please review the [job](${context.payload.repository.url}/actions/runs/${context.runId})`,
               }));

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -55,8 +55,7 @@ jobs:
               repo: 'datagov-deploy'
             }
             const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
-              q: issue_title + "+in:title+type:issue+repo:gsa/datagov-deploy",
-
+              q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
             }))
             if(current_issues.data.items.length > 0) {
               console.log(current_issues.data.items);
@@ -110,11 +109,12 @@ jobs:
               owner: context.repo.owner,
               repo: 'datagov-deploy'
             }
-            const current_issues = await github.issues.listForRepo(Object.assign(base_github_options, {state: 'open'}))
-            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
-            if(current_issue) {
+            const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
+              q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
+            }))
+            if(current_issues.data.items.length > 0) {
               github.issues.createComment(Object.assign(base_github_options, {
-                issue_number: current_issue.number,
+                issue_number: current_issues.data.items[0].number,
                 body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
               }));
             } else {
@@ -162,11 +162,12 @@ jobs:
               owner: context.repo.owner,
               repo: 'datagov-deploy'
             }
-            const current_issues = await github.issues.listForRepo(Object.assign(base_github_options, {state: 'open'}))
-            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
-            if(current_issue) {
+            const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
+              q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
+            }))
+            if(current_issues.data.items.length > 0) {
               github.issues.createComment(Object.assign(base_github_options, {
-                issue_number: current_issue.number,
+                issue_number: current_issues.data.items[0].number,
                 body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
               }));
             } else {
@@ -212,11 +213,12 @@ jobs:
               owner: context.repo.owner,
               repo: 'datagov-deploy'
             }
-            const current_issues = await github.issues.listForRepo(Object.assign(base_github_options, {state: 'open'}))
-            const current_issue = current_issues.data.find(issue => issue.title === issue_title);
-            if(current_issue) {
+            const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
+              q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
+            }))
+            if(current_issues.data.items.length > 0) {
               github.issues.createComment(Object.assign(base_github_options, {
-                issue_number: current_issue.number,
+                issue_number: current_issues.data.items[0].number,
                 body: `The deployment failed again, [latest job](${context.payload.repository.url}/actions/runs/${context.runId})`
               }));
             } else {

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -55,10 +55,10 @@ jobs:
               repo: 'datagov-deploy'
             }
             const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
-              q: issue_title + "+in:title+type:issue+repo:gsa/datagov-deploy",
+              q: "inventory-app+in:title+type:issue+repo:gsa/datagov-deploy",
 
             }))
-            if(current_issues.length > 1) {
+            if(current_issues) {
               console.log(current_issues);
             } else {
               console.log("No matches");

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -55,7 +55,7 @@ jobs:
               repo: 'datagov-deploy'
             }
             const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
-              q: "inventory-app+in:title+type:issue+repo:gsa/datagov-deploy",
+              q: issue_title + "+in:title+type:issue+repo:gsa/datagov-deploy",
 
             }))
             if(current_issues.data.items.length > 0) {

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -44,24 +44,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: deployment failed
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GH_DATAGOV_TOKEN}}
-          script: |
-            const issue_title = `Deploy error on ${context.payload.repository.name}`
-            const base_github_options = {
-              owner: context.repo.owner,
-              repo: 'datagov-deploy'
-            }
-            const current_issues = await github.search.issuesAndPullRequests(Object.assign({}, base_github_options, {
-              q: issue_title + "+in:title+type:issue+state:open+repo:gsa/datagov-deploy"
-            }))
-            if(current_issues.data.items.length > 0) {
-              console.log(current_issues.data.items);
-            } else {
-              console.log("No matches");
-            }
       - name: vendor dependencies
         run: ./vendor-requirements.sh
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
[Working Example](https://github.com/GSA/datagov-deploy/issues/2799). Uses the [github-script action](https://github.com/actions/github-script). Related to https://github.com/GSA/datagov-deploy/issues/2603.

This step should be attachable to any github actions job, and should work (inside the GSA org; need a special permission token to create issues and comment on them; see [here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) for more details).

Would like to harden this before deploying, because if this code is going to be copied and utilized in different repositories for action workflows we do not want to be updating it in 10 different repo's...

Anyone that has a workflow that fails gets an email (I got many while testing this code), so even if this task fails an email will go out to the specific user who merged the commit to main/develop.

Things to consider:
- Can we re-use a task, so we only define this once per action (could not find any documentation one way or another)?
- Should we use [Object.assign or the Spread Operator](https://attacomsian.com/blog/javascript-merge-objects)?
- Should we use any try-catch blocks?