### PR TITLE
fix smoke to ignore full curl output

### DIFF
--- a/bin/smoke.sh
+++ b/bin/smoke.sh
@@ -8,6 +8,6 @@ set -x
 # TODO move smoke tests to python
 
 curl --fail --silent ${APP_URL}/api/action/status_show?$(date +%s) > /dev/null
-[ "200" == "$(curl --silent --fail --write-out %{http_code} ${APP_URL}/dataset?$(date +%s))" ]
+[ "200" == "$(curl --silent --fail -o /dev/null --write-out %{http_code} ${APP_URL}/dataset?$(date +%s))" ]
 
 echo ok


### PR DESCRIPTION
Smoke script printed out full `/dataset` html output AND the status code, and caused deployment to fail on staging. I believe this is the correct fix, tested locally.

Related to https://github.com/GSA/inventory-app/pull/240, and therefore https://github.com/GSA/datagov-deploy/issues/2783