### PR TITLE
[saml2] configure saml2 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,23 @@ CF_SERVICE_AUTH | The service key password.
 CF_SERVICE_USER | The service key username.
 
 
+## Login.gov integration
+
+We use Login.gov as our
+[SAML2](https://github.com/GSA/datagov-deploy/wiki/SAML2-authentication)
+Identity Provider (IdP). Production apps use the production Login.gov instance
+while other apps use the Login.gov identity sandbox.
+
+Each year in March, Login.gov rotates their credentials. See our
+[wiki](https://github.com/GSA/datagov-deploy/wiki/SAML2-authentication#working-with-logingov)
+for details.
+
+Our Service Provider (SP) certificate and key are provided in through
+environment variable and user-provided service.
+
+The Login.gov IdP metadata is stored in file under `config/`.
+
+
 ## License and Contributing
 
 We're so glad you're thinking about re-using and/or contributing to Data.gov!

--- a/README.md
+++ b/README.md
@@ -118,13 +118,11 @@ Create the Redis service for cache
 
     $ cf create-service aws-elasticache-redis redis-dev ${app_name}-redis
 
-Create the secrets service to store secret environment variables (current list)
-
-    $ cf cups ${app_name}-secrets -p "DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY"
-
 Deploy the Solr instance.
 
     $ cf push --vars-file vars.yml ${app_name}-solr
+
+Create the secrets service to store secret environment variables. See [Secrets](#secrets) below.
 
 Deploy the CKAN app.
 
@@ -135,6 +133,23 @@ Ensure the inventory app can reach the Solr app.
     $ cf add-network-policy ${app_name} ${app_name}-solr --protocol tcp --port 8983
 
 You should now be able to visit `https://[ROUTE]`, where `[ROUTE]` is the route reported by `cf app ${app_name}`.
+
+
+### Secrets
+
+Tips on managing
+[secrets](https://github.com/GSA/datagov-deploy/wiki/Cloud.gov-Cheat-Sheet#secrets-management).
+When creating the service for the first time, use `create-user-provided-service`
+instead of update.
+
+    $ cf update-user-provided-service ${app_name}-secrets -p "CKAN___BEAKER__SESSION_SECRET, DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY, SAML2_PRIVATE_KEY"
+
+Name | Description | Where to find
+---- | ----------- | -------------
+CKAN___BEAKER__SESSION__SECRET | Session secret for encrypting CKAN sessions.  | `pwgen -s 32 1`
+DS_RO_PASSWORD | Read-only password to configure for the [datastore](https://docs.ckan.org/en/2.9/maintaining/datastore.html) user. | Initially randomly generated [#2839](https://github.com/GSA/datagov-deploy/issues/2839)
+NEW_RELIC_LICENSE_KEY | New Relic License key. | New Relic account settings.
+SAML2_PRIVATE_KEY | Base64 encoded SAML2 key matching the certificate configured for Login.gov | [Google Drive](https://drive.google.com/drive/u/0/folders/1VguFPRiRb1Ljnm_6UShryHWDofX0xBnU).
 
 
 ### CI configuration

--- a/apt.yml
+++ b/apt.yml
@@ -1,0 +1,3 @@
+---
+packages:
+  - xmlsec1  # required for pysaml2

--- a/cfstart.sh
+++ b/cfstart.sh
@@ -11,6 +11,13 @@ function ckan () {
     paster --plugin=ckan "$@"
 }
 
+function vcap_get_service () {
+  local path service_name
+  service_name="$1"
+  path="$2"
+  echo $VCAP_SERVICES | jq --raw-output --arg service_name "$service_name" ".[][] | select(.name == \$service_name) | $path"
+}
+
 # We need to know the application name ...
 APP_NAME=$(echo $VCAP_APPLICATION | jq -r '.application_name')
 ORG_NAME=$(echo $VCAP_APPLICATION | jq -r '.organization_name')
@@ -28,44 +35,47 @@ SVC_REDIS="${APP_NAME}-redis"
 SVC_SECRETS="${APP_NAME}-secrets"
 
 # We need specific datastore URL components so we can construct another URL for the read-only user
-DS_HOST=$(echo $VCAP_SERVICES | jq -r --arg SVC_DATASTORE $SVC_DATASTORE '.[][] | select(.name == $SVC_DATASTORE) | .credentials.host')
-DS_PORT=$(echo $VCAP_SERVICES | jq -r --arg SVC_DATASTORE $SVC_DATASTORE '.[][] | select(.name == $SVC_DATASTORE) | .credentials.port')
-DS_DBNAME=$(echo $VCAP_SERVICES | jq -r --arg SVC_DATASTORE $SVC_DATASTORE '.[][] | select(.name == $SVC_DATASTORE) | .credentials.db_name')
+DS_HOST=$(vcap_get_service $SVC_DATASTORE .credentials.host)
+DS_PORT=$(vcap_get_service $SVC_DATASTORE .credentials.port)
+DS_DBNAME=$(vcap_get_service $SVC_DATASTORE .credentials.db_name)
 
-# We need the redis credentials for ckan to access redis, and we need to build the url to use the rediss 
-REDIS_HOST=$(echo $VCAP_SERVICES | jq -r --arg SVC_REDIS $SVC_REDIS '.[][] | select(.name == $SVC_REDIS) | .credentials.host')
-REDIS_PASSWORD=$(echo $VCAP_SERVICES | jq -r --arg SVC_REDIS $SVC_REDIS '.[][] | select(.name == $SVC_REDIS) | .credentials.password')
-REDIS_PORT=$(echo $VCAP_SERVICES | jq -r --arg SVC_REDIS $SVC_REDIS '.[][] | select(.name == $SVC_REDIS) | .credentials.port')
+# We need the redis credentials for ckan to access redis, and we need to build the url to use the rediss
+REDIS_HOST=$(vcap_get_service $SVC_REDIS .credentials.host)
+REDIS_PASSWORD=$(vcap_get_service $SVC_REDIS .credentials.password)
+REDIS_PORT=$(vcap_get_service $SVC_REDIS .credentials.port)
 
+SAML2_PRIVATE_KEY=$(vcap_get_service $SVC_SECRETS .credentials.SAML2_PRIVATE_KEY)
 SECRETS_DIR=$(mktemp -d)
+
 export CKANEXT__SAML2AUTH__KEY_FILE_PATH=${SECRETS_DIR}/saml2_key.pem
 export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${SECRETS_DIR}/saml2_certificate.pem
 
-echo "$SAML2_PRIVATE_KEY" | base64 -d > $CKANEXT__SAML2AUTH__KEY_FILE_PATH
-echo "$SAML2_CERTIFICATE" > $CKANEXT__SAML2AUTH__CERT_FILE_PATH
-
 # We need the secret credentials for various application components (DB configuration, license keys, etc)
-DS_RO_PASSWORD=$(echo $VCAP_SERVICES | jq -r --arg SVC_SECRETS $SVC_SECRETS '.[][] | select(.name == $SVC_SECRETS) | .credentials.DS_RO_PASSWORD')
-export NEW_RELIC_LICENSE_KEY=$(echo $VCAP_SERVICES | jq -r --arg SVC_SECRETS $SVC_SECRETS '.[][] | select(.name == $SVC_SECRETS) | .credentials.NEW_RELIC_LICENSE_KEY')
-export CKAN___BEAKER__SESSION__SECRET=$(echo $VCAP_SERVICES | jq -r --arg SVC_SECRETS $SVC_SECRETS '.[][] | select(.name == $SVC_SECRETS) | .credentials.CKAN___BEAKER__SESSION__SECRET')
+DS_RO_PASSWORD=$(vcap_get_service $SVC_SECRETS .credentials.DS_RO_PASSWORD)
+export NEW_RELIC_LICENSE_KEY=$(vcap_get_service $SVC_SECRETS .credentials.NEW_RELIC_LICENSE_KEY)
+export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service $SVC_SECRETS .credentials.CKAN___BEAKER__SESSION__SECRET)
 
 # ckan reads some environment variables... https://docs.ckan.org/en/2.8/maintaining/configuration.html#environment-variables
-export CKAN_SQLALCHEMY_URL=$(echo $VCAP_SERVICES | jq -r --arg SVC_DATABASE $SVC_DATABASE '.[][] | select(.name == $SVC_DATABASE) | .credentials.uri')
+export CKAN_SQLALCHEMY_URL=$(vcap_get_service $SVC_DATABASE .credentials.uri)
 export CKAN___BEAKER__SESSION__URL=${CKAN_SQLALCHEMY_URL}
 export CKAN_SITE_URL=https://$APP_URL
 export CKAN_SITE_ID=$ORG_NAME-$SPACE_NAME-$APP_NAME
 export CKAN_SOLR_URL=$SOLR_URL
-export CKAN_DATASTORE_WRITE_URL=$(echo $VCAP_SERVICES | jq -r --arg SVC_DATASTORE $SVC_DATASTORE '.[][] | select(.name == $SVC_DATASTORE) | .credentials.uri')
+export CKAN_DATASTORE_WRITE_URL=$(vcap_get_service $SVC_DATASTORE .credentials.uri)
 export CKAN_DATASTORE_READ_URL=postgres://$DS_RO_USER:$DS_RO_PASSWORD@$DS_HOST:$DS_PORT/$DS_DBNAME
 export CKAN_REDIS_URL=rediss://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT
 export CKAN_STORAGE_PATH=/home/vcap/app/files
 
 # Use ckanext-envvars to import other configurations...
-export CKANEXT__S3FILESTORE__REGION_NAME=$(echo $VCAP_SERVICES | jq -r --arg SVC_S3 $SVC_S3 '.[][] | select(.name == $SVC_S3) | .credentials.region')
+export CKANEXT__S3FILESTORE__REGION_NAME=$(vcap_get_service $SVC_S3 .credentials.region)
 export CKANEXT__S3FILESTORE__HOST_NAME=https://s3-$CKANEXT__S3FILESTORE__REGION_NAME.amazonaws.com
-export CKANEXT__S3FILESTORE__AWS_ACCESS_KEY_ID=$(echo $VCAP_SERVICES | jq -r --arg SVC_S3 $SVC_S3 '.[][] | select(.name == $SVC_S3) | .credentials.access_key_id')
-export CKANEXT__S3FILESTORE__AWS_SECRET_ACCESS_KEY=$(echo $VCAP_SERVICES | jq -r --arg SVC_S3 $SVC_S3 '.[][] | select(.name == $SVC_S3) | .credentials.secret_access_key')
-export CKANEXT__S3FILESTORE__AWS_BUCKET_NAME=$(echo $VCAP_SERVICES | jq -r --arg SVC_S3 $SVC_S3 '.[][] | select(.name == $SVC_S3) | .credentials.bucket')
+export CKANEXT__S3FILESTORE__AWS_ACCESS_KEY_ID=$(vcap_get_service $SVC_S3 .credentials.access_key_id)
+export CKANEXT__S3FILESTORE__AWS_SECRET_ACCESS_KEY=$(vcap_get_service $SVC_S3 .credentials.secret_access_key)
+export CKANEXT__S3FILESTORE__AWS_BUCKET_NAME=$(vcap_get_service $SVC_S3 .credentials.bucket)
+
+# Write out any files
+echo "$SAML2_PRIVATE_KEY" | base64 -d > $CKANEXT__SAML2AUTH__KEY_FILE_PATH
+echo "$SAML2_CERTIFICATE" > $CKANEXT__SAML2AUTH__CERT_FILE_PATH
 
 # Edit the config file to use validate debug is off and utilizes the correct port
 export CKAN_INI=config/production.ini

--- a/cfstart.sh
+++ b/cfstart.sh
@@ -37,6 +37,13 @@ REDIS_HOST=$(echo $VCAP_SERVICES | jq -r --arg SVC_REDIS $SVC_REDIS '.[][] | sel
 REDIS_PASSWORD=$(echo $VCAP_SERVICES | jq -r --arg SVC_REDIS $SVC_REDIS '.[][] | select(.name == $SVC_REDIS) | .credentials.password')
 REDIS_PORT=$(echo $VCAP_SERVICES | jq -r --arg SVC_REDIS $SVC_REDIS '.[][] | select(.name == $SVC_REDIS) | .credentials.port')
 
+SECRETS_DIR=$(mktemp -d)
+export CKANEXT__SAML2AUTH__KEY_FILE_PATH=${SECRETS_DIR}/saml2_key.pem
+export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${SECRETS_DIR}/saml2_certificate.pem
+
+echo "$SAML2_PRIVATE_KEY" | base64 -d > $CKANEXT__SAML2AUTH__KEY_FILE_PATH
+echo "$SAML2_CERTIFICATE" > $CKANEXT__SAML2AUTH__CERT_FILE_PATH
+
 # We need the secret credentials for various application components (DB configuration, license keys, etc)
 DS_RO_PASSWORD=$(echo $VCAP_SERVICES | jq -r --arg SVC_SECRETS $SVC_SECRETS '.[][] | select(.name == $SVC_SECRETS) | .credentials.DS_RO_PASSWORD')
 export NEW_RELIC_LICENSE_KEY=$(echo $VCAP_SERVICES | jq -r --arg SVC_SECRETS $SVC_SECRETS '.[][] | select(.name == $SVC_SECRETS) | .credentials.NEW_RELIC_LICENSE_KEY')

--- a/cfstart.sh
+++ b/cfstart.sh
@@ -12,9 +12,10 @@ function ckan () {
 }
 
 function vcap_get_service () {
-  local path service_name
-  service_name="$1"
+  local path name
+  name="$1"
   path="$2"
+  service_name=${APP_NAME}-${name}
   echo $VCAP_SERVICES | jq --raw-output --arg service_name "$service_name" ".[][] | select(.name == \$service_name) | $path"
 }
 
@@ -24,59 +25,43 @@ SHARED_DIR=$(mktemp -d)
 
 # We need to know the application name ...
 APP_NAME=$(echo $VCAP_APPLICATION | jq -r '.application_name')
-ORG_NAME=$(echo $VCAP_APPLICATION | jq -r '.organization_name')
-SPACE_NAME=$(echo $VCAP_APPLICATION | jq -r '.space_name')
-
-# We need the public URL for the configuration file
 APP_URL=$(echo $VCAP_APPLICATION | jq -r '.application_uris[0]')
 
-# ... from which we can guess the service names
-
-SVC_DATABASE="${APP_NAME}-db"
-SVC_DATASTORE="${APP_NAME}-datastore"
-SVC_S3="${APP_NAME}-s3"
-SVC_REDIS="${APP_NAME}-redis"
-SVC_SECRETS="${APP_NAME}-secrets"
-
 # We need specific datastore URL components so we can construct another URL for the read-only user
-DS_HOST=$(vcap_get_service $SVC_DATASTORE .credentials.host)
-DS_PORT=$(vcap_get_service $SVC_DATASTORE .credentials.port)
-DS_DBNAME=$(vcap_get_service $SVC_DATASTORE .credentials.db_name)
+DS_HOST=$(vcap_get_service datastore .credentials.host)
+DS_PORT=$(vcap_get_service datastore .credentials.port)
+DS_DBNAME=$(vcap_get_service datastore .credentials.db_name)
 
 # We need the redis credentials for ckan to access redis, and we need to build the url to use the rediss
-REDIS_HOST=$(vcap_get_service $SVC_REDIS .credentials.host)
-REDIS_PASSWORD=$(vcap_get_service $SVC_REDIS .credentials.password)
-REDIS_PORT=$(vcap_get_service $SVC_REDIS .credentials.port)
+REDIS_HOST=$(vcap_get_service redis .credentials.host)
+REDIS_PASSWORD=$(vcap_get_service redis .credentials.password)
+REDIS_PORT=$(vcap_get_service redis .credentials.port)
 
-SAML2_PRIVATE_KEY=$(vcap_get_service $SVC_SECRETS .credentials.SAML2_PRIVATE_KEY)
+SAML2_PRIVATE_KEY=$(vcap_get_service secrets .credentials.SAML2_PRIVATE_KEY)
 
 export CKANEXT__SAML2AUTH__KEY_FILE_PATH=${CONFIG_DIR}/saml2_key.pem
 export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${CONFIG_DIR}/saml2_certificate.pem
-export CKANEXT__SAML2AUTH__IDP_METADATA__REMOTE_CERT=${CONFIG_DIR}/saml2_idp_certificate.pem
-#export CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH=${CONFIG_DIR}/idp.xml
 
 # We need the secret credentials for various application components (DB configuration, license keys, etc)
-DS_RO_PASSWORD=$(vcap_get_service $SVC_SECRETS .credentials.DS_RO_PASSWORD)
-export NEW_RELIC_LICENSE_KEY=$(vcap_get_service $SVC_SECRETS .credentials.NEW_RELIC_LICENSE_KEY)
-export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service $SVC_SECRETS .credentials.CKAN___BEAKER__SESSION__SECRET)
+DS_RO_PASSWORD=$(vcap_get_service secrets .credentials.DS_RO_PASSWORD)
+export NEW_RELIC_LICENSE_KEY=$(vcap_get_service secrets .credentials.NEW_RELIC_LICENSE_KEY)
+export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION__SECRET)
 
 # ckan reads some environment variables... https://docs.ckan.org/en/2.8/maintaining/configuration.html#environment-variables
-export CKAN_SQLALCHEMY_URL=$(vcap_get_service $SVC_DATABASE .credentials.uri)
+export CKAN_SQLALCHEMY_URL=$(vcap_get_service db .credentials.uri)
 export CKAN___BEAKER__SESSION__URL=${CKAN_SQLALCHEMY_URL}
 export CKAN_SITE_URL=https://$APP_URL
-export CKAN_SITE_ID=$ORG_NAME-$SPACE_NAME-$APP_NAME
-export CKAN_SOLR_URL=$SOLR_URL
-export CKAN_DATASTORE_WRITE_URL=$(vcap_get_service $SVC_DATASTORE .credentials.uri)
+export CKAN_DATASTORE_WRITE_URL=$(vcap_get_service datastore .credentials.uri)
 export CKAN_DATASTORE_READ_URL=postgres://$DS_RO_USER:$DS_RO_PASSWORD@$DS_HOST:$DS_PORT/$DS_DBNAME
 export CKAN_REDIS_URL=rediss://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT
 export CKAN_STORAGE_PATH=${SHARED_DIR}/files
 
 # Use ckanext-envvars to import other configurations...
-export CKANEXT__S3FILESTORE__REGION_NAME=$(vcap_get_service $SVC_S3 .credentials.region)
+export CKANEXT__S3FILESTORE__REGION_NAME=$(vcap_get_service s3 .credentials.region)
 export CKANEXT__S3FILESTORE__HOST_NAME=https://s3-$CKANEXT__S3FILESTORE__REGION_NAME.amazonaws.com
-export CKANEXT__S3FILESTORE__AWS_ACCESS_KEY_ID=$(vcap_get_service $SVC_S3 .credentials.access_key_id)
-export CKANEXT__S3FILESTORE__AWS_SECRET_ACCESS_KEY=$(vcap_get_service $SVC_S3 .credentials.secret_access_key)
-export CKANEXT__S3FILESTORE__AWS_BUCKET_NAME=$(vcap_get_service $SVC_S3 .credentials.bucket)
+export CKANEXT__S3FILESTORE__AWS_ACCESS_KEY_ID=$(vcap_get_service s3 .credentials.access_key_id)
+export CKANEXT__S3FILESTORE__AWS_SECRET_ACCESS_KEY=$(vcap_get_service s3 .credentials.secret_access_key)
+export CKANEXT__S3FILESTORE__AWS_BUCKET_NAME=$(vcap_get_service s3 .credentials.bucket)
 
 # Write out any files and directories
 mkdir -p $CKAN_STORAGE_PATH

--- a/cfstart.sh
+++ b/cfstart.sh
@@ -52,6 +52,8 @@ SAML2_PRIVATE_KEY=$(vcap_get_service $SVC_SECRETS .credentials.SAML2_PRIVATE_KEY
 
 export CKANEXT__SAML2AUTH__KEY_FILE_PATH=${CONFIG_DIR}/saml2_key.pem
 export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${CONFIG_DIR}/saml2_certificate.pem
+export CKANEXT__SAML2AUTH__IDP_METADATA__REMOTE_CERT=${CONFIG_DIR}/saml2_idp_certificate.pem
+#export CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH=${CONFIG_DIR}/idp.xml
 
 # We need the secret credentials for various application components (DB configuration, license keys, etc)
 DS_RO_PASSWORD=$(vcap_get_service $SVC_SECRETS .credentials.DS_RO_PASSWORD)

--- a/config/login.sandbox.idp.xml
+++ b/config/login.sandbox.idp.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" ID="_50faff30-551d-0139-2a83-06a6af38cd4f" entityID="https://idp.int.identitysandbox.gov/api/saml">
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_50faff30-551d-0139-2a83-06a6af38cd4f">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>zbYoutkess5CHJAZtH9jguqY3rnlFJVc9IZZjmDhCoU=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>Bcnqjisuu3kM/h9CJp6w9mwVYanB2q4PRYgFVGiUODEnpm+G0QjZlzqieBc5bdOzlxw0ka1ivtjXRMNJdZrainQWdNpuc1PYEF/umNE8fM7uHOCFA1NmBz7NoDVob63a+avOFOgzmH/Y/U3K8uVhGVS23q+ht9wppDuVBjboQydSC6UDAltQxSkKLFfFu4okb2HVrOoC2Rdan9YMZlwuEw/Rjugh8uVOFinJp2CehWxtqjmACUBlcLhFah/3VFPzY72eDgwhLZ7Op5lQdkNCCtgN12tyOaAyBlIy1w5agh+o+bptOVqgX7wu0UxV2Vev8M0g49QcwTcv7/Uyfm+u5w==</ds:SignatureValue>
+    <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <ds:X509Data>
+        <ds:X509Certificate>MIIDgDCCAmgCCQCBwmwOs+Ve3DANBgkqhkiG9w0BAQsFADCBgTELMAkGA1UEBhMCVVMxHTAbBgNVBAgMFERpc3RyaWN0IG9mIENvbHVtYmlhMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzESMBAGA1UECwwJTG9naW4uZ292MSMwIQYDVQQDDBpzZWN1cmUuaWRlbnRpdHlzYW5kYm94LmdvdjAeFw0yMDAzMTAxOTE0MzhaFw0yMTA0MDExOTE0MzhaMIGBMQswCQYDVQQGEwJVUzEdMBsGA1UECAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExDDAKBgNVBAoMA0dTQTEMMAoGA1UECwwDVFRTMRIwEAYDVQQLDAlMb2dpbi5nb3YxIzAhBgNVBAMMGnNlY3VyZS5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnpLbLzqL+7Xxa8HrxhX6DNBmpWvpldrT9Z8JKgFOjPuZZT1TPYpE6b2fL1M49SDCXudFssbgcX2BBGZsvZ96UGtKP0dz4Sy+RqWwSUBrptMwcayM5TGu0AW5kGDbb0ZC2M7jspHOZ1bdPdT3BGbyHIrCwBVwlyLSBeztACQTebmCaW5fioJnpigbMmGCpLm4zFYOLYmR1fEHgWNrw51rhxhb3OEODX5Wjp6F86oEqgJFmV4pq8ggL3qEKbNwpvm3QMUvQ1QmZh8bIBvp9BYcgTjCBFDYwTdR5KQpZHtSqdHjaxfDq3TJPUqVB+LMb9STjU/qKcvg/IbmwzQ0tDdzgQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBqcIhjTzbUOugSx7bkKwiS0qjpVgmZnvbb//eQeTmKuMquvy/DW1Lon9X6QBIvkwJMKMfgZVfTwV9C3h4kkPXnhZNt4HH0TPBqZZwprFoEOhqkjmx6jD5OdrVw/d505Q11lsb7yN7sOwJ0/Q26Ru3BA5sFCtAXM3TB9JGCZs2s/5Geut2Q6MTUMVutjsCPRRwpJ0ls22e5hxQRIuXjJf6tAOCVdt4YYbkYgcXYNe36N/zoZmnJOPZDtumCBcB9XsQw14G4kWHW38EaFpIY8yFt5p4k+8DbC6DTqgxOfYUWpmY9IGGS4A2Buwqh7rJcjv1g3f68Tz2vXphnfi5rmN4Y</ds:X509Certificate>
+      </ds:X509Data>
+    </KeyInfo>
+  </ds:Signature>
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIDgDCCAmgCCQCBwmwOs+Ve3DANBgkqhkiG9w0BAQsFADCBgTELMAkGA1UEBhMCVVMxHTAbBgNVBAgMFERpc3RyaWN0IG9mIENvbHVtYmlhMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzESMBAGA1UECwwJTG9naW4uZ292MSMwIQYDVQQDDBpzZWN1cmUuaWRlbnRpdHlzYW5kYm94LmdvdjAeFw0yMDAzMTAxOTE0MzhaFw0yMTA0MDExOTE0MzhaMIGBMQswCQYDVQQGEwJVUzEdMBsGA1UECAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExDDAKBgNVBAoMA0dTQTEMMAoGA1UECwwDVFRTMRIwEAYDVQQLDAlMb2dpbi5nb3YxIzAhBgNVBAMMGnNlY3VyZS5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnpLbLzqL+7Xxa8HrxhX6DNBmpWvpldrT9Z8JKgFOjPuZZT1TPYpE6b2fL1M49SDCXudFssbgcX2BBGZsvZ96UGtKP0dz4Sy+RqWwSUBrptMwcayM5TGu0AW5kGDbb0ZC2M7jspHOZ1bdPdT3BGbyHIrCwBVwlyLSBeztACQTebmCaW5fioJnpigbMmGCpLm4zFYOLYmR1fEHgWNrw51rhxhb3OEODX5Wjp6F86oEqgJFmV4pq8ggL3qEKbNwpvm3QMUvQ1QmZh8bIBvp9BYcgTjCBFDYwTdR5KQpZHtSqdHjaxfDq3TJPUqVB+LMb9STjU/qKcvg/IbmwzQ0tDdzgQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBqcIhjTzbUOugSx7bkKwiS0qjpVgmZnvbb//eQeTmKuMquvy/DW1Lon9X6QBIvkwJMKMfgZVfTwV9C3h4kkPXnhZNt4HH0TPBqZZwprFoEOhqkjmx6jD5OdrVw/d505Q11lsb7yN7sOwJ0/Q26Ru3BA5sFCtAXM3TB9JGCZs2s/5Geut2Q6MTUMVutjsCPRRwpJ0ls22e5hxQRIuXjJf6tAOCVdt4YYbkYgcXYNe36N/zoZmnJOPZDtumCBcB9XsQw14G4kWHW38EaFpIY8yFt5p4k+8DbC6DTqgxOfYUWpmY9IGGS4A2Buwqh7rJcjv1g3f68Tz2vXphnfi5rmN4Y</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.int.identitysandbox.gov/api/saml/auth2020"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.int.identitysandbox.gov/api/saml/auth2020"/>
+  </IDPSSODescriptor>
+  <AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIDgDCCAmgCCQCBwmwOs+Ve3DANBgkqhkiG9w0BAQsFADCBgTELMAkGA1UEBhMCVVMxHTAbBgNVBAgMFERpc3RyaWN0IG9mIENvbHVtYmlhMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzESMBAGA1UECwwJTG9naW4uZ292MSMwIQYDVQQDDBpzZWN1cmUuaWRlbnRpdHlzYW5kYm94LmdvdjAeFw0yMDAzMTAxOTE0MzhaFw0yMTA0MDExOTE0MzhaMIGBMQswCQYDVQQGEwJVUzEdMBsGA1UECAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExDDAKBgNVBAoMA0dTQTEMMAoGA1UECwwDVFRTMRIwEAYDVQQLDAlMb2dpbi5nb3YxIzAhBgNVBAMMGnNlY3VyZS5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnpLbLzqL+7Xxa8HrxhX6DNBmpWvpldrT9Z8JKgFOjPuZZT1TPYpE6b2fL1M49SDCXudFssbgcX2BBGZsvZ96UGtKP0dz4Sy+RqWwSUBrptMwcayM5TGu0AW5kGDbb0ZC2M7jspHOZ1bdPdT3BGbyHIrCwBVwlyLSBeztACQTebmCaW5fioJnpigbMmGCpLm4zFYOLYmR1fEHgWNrw51rhxhb3OEODX5Wjp6F86oEqgJFmV4pq8ggL3qEKbNwpvm3QMUvQ1QmZh8bIBvp9BYcgTjCBFDYwTdR5KQpZHtSqdHjaxfDq3TJPUqVB+LMb9STjU/qKcvg/IbmwzQ0tDdzgQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBqcIhjTzbUOugSx7bkKwiS0qjpVgmZnvbb//eQeTmKuMquvy/DW1Lon9X6QBIvkwJMKMfgZVfTwV9C3h4kkPXnhZNt4HH0TPBqZZwprFoEOhqkjmx6jD5OdrVw/d505Q11lsb7yN7sOwJ0/Q26Ru3BA5sFCtAXM3TB9JGCZs2s/5Geut2Q6MTUMVutjsCPRRwpJ0ls22e5hxQRIuXjJf6tAOCVdt4YYbkYgcXYNe36N/zoZmnJOPZDtumCBcB9XsQw14G4kWHW38EaFpIY8yFt5p4k+8DbC6DTqgxOfYUWpmY9IGGS4A2Buwqh7rJcjv1g3f68Tz2vXphnfi5rmN4Y</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <Organization>
+      <OrganizationName xml:lang="en">18F</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">18F</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">http://18f.gsa.gov</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="technical"/>
+    <AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.int.identitysandbox.gov/api/saml/attributes"/>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress</NameIDFormat>
+  </AttributeAuthorityDescriptor>
+  <Organization>
+    <OrganizationName xml:lang="en">18F</OrganizationName>
+    <OrganizationDisplayName xml:lang="en">18F</OrganizationDisplayName>
+    <OrganizationURL xml:lang="en">http://18f.gsa.gov</OrganizationURL>
+  </Organization>
+  <ContactPerson contactType="technical"/>
+</EntityDescriptor>

--- a/config/production.ini
+++ b/config/production.ini
@@ -33,7 +33,7 @@ ckanext.datajson.url_enabled = False
 # This is the secret token that the beaker library uses to hash the cookie sent
 # to the client. `paster make-config` generates a unique value for this each
 # time it generates a config file.
-beaker.session.secret = {{ckan_instance_secret}}
+#beaker.session.secret = {{ckan_instance_secret}}
 
 beaker.session.type=ext:database
 beaker.session.cookie_expires=true
@@ -100,7 +100,7 @@ ckan.redis.url = rediss://:REDIS_PASSWORD@REDIS_HOST:REDIS_PORT
 #       Add ``pdf_preview`` to enable the resource preview for PDFs
 #		Add ``resource_proxy`` to enable resorce proxying and get around the
 #		same origin policy
-ckan.plugins = datagov_inventory usmetadata datajson datastore datapusher stats text_view recline_view googleanalyticsbasic dcat_usmetadata s3filestore envvars
+ckan.plugins = datagov_inventory usmetadata datajson datastore datapusher stats text_view recline_view googleanalyticsbasic dcat_usmetadata s3filestore saml2auth envvars
 
 ckan.views.default_views = recline_view text_view image_view webpage_view recline_grid_view
 
@@ -129,17 +129,17 @@ ckan.locales_offered =
 ckan.locales_filtered_out = en_GB
 
 ## SAML2auth Settings
-ckanext.saml2auth.idp_metadata.local_path=/etc/ckan/saml2/idp.xml
-ckanext.saml2auth.key_file_path=/etc/ckan/saml2/pki/mykey.pem
-ckanext.saml2auth.cert_file_path=/etc/ckan/saml2/pki/mycert.pem
+#ckanext.saml2auth.key_file_path=/etc/ckan/saml2/pki/mykey.pem
+#ckanext.saml2auth.cert_file_path=/etc/ckan/saml2/pki/mycert.pem
 
-ckanext.saml2auth.idp_metadata.location=local
+ckanext.saml2auth.idp_metadata.location=remote
+ckanext.saml2auth.idp_metadata.remote_url=https://idp.int.identitysandbox.gov/api/saml/metadata2020
 ckanext.saml2auth.user_firstname=first_name
 ckanext.saml2auth.user_lastname=last_name
 ckanext.saml2auth.user_email=email
 ckanext.saml2auth.allow_unknown_attributes=true
 ckanext.saml2auth.sp.name_id_format=urn:oasis:names:tc:saml:2.0:nameid-format:persistent urn:oasis:names:tc:saml:2.0:nameid-format:transient n:oasis:names:tc:saml:2.0:nameid-format:emailaddress
-ckanext.saml2auth.entity_id=urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-sandbox-inventory
+#ckanext.saml2auth.entity_id=urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-sandbox-inventory
 ckanext.saml2auth.want_response_signed=false
 ckanext.saml2auth.want_assertions_signed=false
 ckanext.saml2auth.want_assertions_or_response_signed=true

--- a/config/production.ini
+++ b/config/production.ini
@@ -33,11 +33,11 @@ ckanext.datajson.url_enabled = False
 # This is the secret token that the beaker library uses to hash the cookie sent
 # to the client. `paster make-config` generates a unique value for this each
 # time it generates a config file.
-#beaker.session.secret = {{ckan_instance_secret}}
+#beaker.session.secret = $CKAN___BEAKER__SESSION__SECRET
 
 beaker.session.type=ext:database
 beaker.session.cookie_expires=true
-beaker.session.url=%(sqlalchemy.url)s
+#beaker.session.url = $CKAN___BEAKER__SESSION__URL
 # 3000 seconds = 50 mins
 beaker.session.timeout=3000
 beaker.session.lock_dir=/var/tmp/ckan/lock
@@ -55,19 +55,19 @@ who.timeout = 3000
 # who.httponly = True # DEFAULT True already
 who.secure = True
 
-## Database Settings to be overwritten per environment
-sqlalchemy.url = postgresql://ckan:pass@db/ckan
+## Database Settings
+#sqlalchemy.url = $CKAN_SQLALCHEMY_URL
 
-ckan.datastore.write_url = postgresql://datastore:pass@datastore/datastore
-ckan.datastore.read_url = postgresql://datastore_ro:pass@datastore/datastore
+#ckan.datastore.write_url = $CKAN_DATASTORE_WRITE_URL
+#ckan.datastore.read_url = $CKAN_DATASTORE_READ_URL
 
 # PostgreSQL' full-text search parameters
 ckan.datastore.default_fts_lang = english
 ckan.datastore.default_fts_index_method = gist
 
 ## Site Settings
-# external url no trailing slash, to be overwritten per environment
-ckan.site_url = http://localhost:5000
+# external url no trailing slash
+#ckan.site_url = $CKAN_SITE_URL
 
 ## Authorization Settings
 
@@ -83,16 +83,14 @@ ckan.auth.create_user_via_web = false
 ckan.auth.roles_that_cascade_to_sub_groups = admin
 ckan.auth.public_user_details = false
 
-## Search Settings, to be overwritten per environment
-
-ckan.site_id = inventory
-solr_url = http://inventory-solr.apps.internal:8983/solr/ckan2_8
+## Search Settings
+#ckan.site_id = $CKAN_SITE_ID
+#solr_url = $CKAN_SOLR_URL
 
 #ckan.simple_search = 1
 
-## Redis Settings, to be overwritten per environment
-# Set by environment
-ckan.redis.url = rediss://:REDIS_PASSWORD@REDIS_HOST:REDIS_PORT
+## Redis Settings
+#ckan.redis.url = $CKAN_REDIS_URL
 
 ## Plugins Settings
 
@@ -129,19 +127,19 @@ ckan.locales_offered =
 ckan.locales_filtered_out = en_GB
 
 ## SAML2auth Settings
-#ckanext.saml2auth.key_file_path=/etc/ckan/saml2/pki/mykey.pem
-#ckanext.saml2auth.cert_file_path=/etc/ckan/saml2/pki/mycert.pem
+#ckanext.saml2auth.key_file_path = $CKANEXT__SAML2AUTH__KEY_FILE_PATH
+#ckanext.saml2auth.cert_file_path = $CKANEXT__SAML2AUTH__CERT_FILE_PATH
 
 # TODO fetch and verify remote metadata https://github.com/GSA/datagov-deploy/issues/2860
 ckanext.saml2auth.idp_metadata.location=local
-#ckanext.saml2auth.idp_metadata.local_path =
+#ckanext.saml2auth.idp_metadata.local_path = $CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH
 
 ckanext.saml2auth.user_firstname=first_name
 ckanext.saml2auth.user_lastname=last_name
 ckanext.saml2auth.user_email=email
 ckanext.saml2auth.allow_unknown_attributes=true
 ckanext.saml2auth.sp.name_id_format=urn:oasis:names:tc:saml:2.0:nameid-format:persistent urn:oasis:names:tc:saml:2.0:nameid-format:transient n:oasis:names:tc:saml:2.0:nameid-format:emailaddress
-#ckanext.saml2auth.entity_id=urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-sandbox-inventory
+#ckanext.saml2auth.entity_id = $CKANEXT__SAML2AUTH__ENTITY_ID
 ckanext.saml2auth.want_response_signed=false
 ckanext.saml2auth.want_assertions_signed=false
 ckanext.saml2auth.want_assertions_or_response_signed=true
@@ -168,19 +166,16 @@ ckan.feeds.author_link =
 #ckan.resource_proxy.chunk_size = 4096
 
 # The maximum content size, in bytes, for uploads
-ckan.storage.max_content_length = 650000000
+ckan.storage.max_content_length = 536870912
+#ckan.storage_path = CKAN_STORAGE_PATH
 
-# To be overwritten per environment using CKAN_STORAGE_PATH
-ckan.storage_path = /var/lib/ckan/files
-
-ckanext.s3filestore.region_name = us-east-1
-ckanext.s3filestore.signature_version = s3v4
-
-# The following s3 variables are set per environment
-ckanext.s3filestore.aws_bucket_name = inventory-s3-bucket
+#ckanext.s3filestore.aws_access_key_id = $CKANEXT__S3FILESTORE__AWS_ACCESS_KEY_ID
+#ckanext.s3filestore.aws_bucket_name = $CKANEXT__S3FILESTORE__AWS_BUCKET_NAME
+#ckanext.s3filestore.aws_secret_access_key = $CKANEXT__S3FILESTORE__AWS_SECRET_ACCESS_KEY
+#ckanext.s3filestore.host_name = $CKANEXT__S3FILESTORE__HOST_NAME
+#ckanext.s3filestore.region_name = $CKANEXT__S3FILESTORE__REGION_NAME
 ckanext.s3filestore.aws_storage_path = inventory
-ckanext.s3filestore.aws_access_key_id = _placeholder
-ckanext.s3filestore.aws_secret_access_key = _placeholder
+ckanext.s3filestore.signature_version = s3v4
 
 #ckan.max_resource_size = 650
 #ckan.max_image_size = 2

--- a/config/production.ini
+++ b/config/production.ini
@@ -132,8 +132,10 @@ ckan.locales_filtered_out = en_GB
 #ckanext.saml2auth.key_file_path=/etc/ckan/saml2/pki/mykey.pem
 #ckanext.saml2auth.cert_file_path=/etc/ckan/saml2/pki/mycert.pem
 
-ckanext.saml2auth.idp_metadata.location=remote
-ckanext.saml2auth.idp_metadata.remote_url=https://idp.int.identitysandbox.gov/api/saml/metadata2020
+# TODO fetch and verify remote metadata https://github.com/GSA/datagov-deploy/issues/2860
+ckanext.saml2auth.idp_metadata.location=local
+#ckanext.saml2auth.idp_metadata.local_path =
+
 ckanext.saml2auth.user_firstname=first_name
 ckanext.saml2auth.user_lastname=last_name
 ckanext.saml2auth.user_email=email

--- a/manifest.yml
+++ b/manifest.yml
@@ -22,7 +22,8 @@ applications:
       DS_RO_USER: datastore_default
       CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
       CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
-      SOLR_URL: http://((solr_route)):8983/solr/ckan2_8
+      CKAN_SITE_ID: inventory
+      CKAN_SOLR_URL: http://((solr_route)):8983/solr/ckan2_8
       NEW_RELIC_APP_NAME: ((app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_LOG: /var/log/new_relic.log

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ applications:
   - name: ((app_name))
     instances: ((instances))
     buildpacks:
+      - https://github.com/cloudfoundry/apt-buildpack
       - https://github.com/cloudfoundry/python-buildpack#v1.7.6
     routes: ((routes))
     services:

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,7 +19,8 @@ applications:
       - ((app_name))-secrets   # cf cups ((app_name))-secrets -p "DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY"
     env:
       DS_RO_USER: datastore_default
-      CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext.saml2auth.entity_id))
+      CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext__saml2auth__entity_id))
+      CKANEXT__SAML2AUTH__IDP_METADATA__LOCAL_PATH: ((ckanext__saml2auth__idp_metadata__local_path))
       SOLR_URL: http://((solr_route)):8983/solr/ckan2_8
       NEW_RELIC_APP_NAME: ((app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,9 +19,11 @@ applications:
       - ((app_name))-secrets   # cf cups ((app_name))-secrets -p "DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY"
     env:
       DS_RO_USER: datastore_default
+      CKANEXT__SAML2AUTH__ENTITY_ID: ((ckanext.saml2auth.entity_id))
       SOLR_URL: http://((solr_route)):8983/solr/ckan2_8
       NEW_RELIC_APP_NAME: ((app_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_LOG: /var/log/new_relic.log
       NEW_RELIC_LOG_LEVEL: info
       NEW_RELIC_MONITOR_MODE: False
+      SAML2_CERTIFICATE: ((saml2_certificate))

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -1,10 +1,36 @@
 app_name: inventory
 
+ckanext.saml2auth.entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-development-inventory
+
+
 # Number of application instances to run in cloud.gov
 instances: 1
 
 routes:
   - route: inventory-dev-datagov.app.cloud.gov
+
+saml2_certificate: |
+  -----BEGIN CERTIFICATE-----
+  MIIDgjCCAmoCCQC/mWj+8OuFxjANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC
+  VVMxCzAJBgNVBAgMAkRDMRMwEQYDVQQHDApXYXNoaW5ndG9uMQwwCgYDVQQKDANH
+  U0ExDDAKBgNVBAsMA1RUUzERMA8GA1UEAwwIRGF0YS5nb3YxIjAgBgkqhkiG9w0B
+  CQEWE2RhdGFnb3ZoZWxwQGdzYS5nb3YwHhcNMjEwMjE3MjMzOTQzWhcNMjMwMjE3
+  MjMzOTQzWjCBgjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkRDMRMwEQYDVQQHDApX
+  YXNoaW5ndG9uMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzERMA8GA1UEAwwI
+  RGF0YS5nb3YxIjAgBgkqhkiG9w0BCQEWE2RhdGFnb3ZoZWxwQGdzYS5nb3YwggEi
+  MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC83/UmBtzwFaK8FNdTfRI5zt8+
+  umvzpg1LTRXEj8E9ywb/gG8dmg957S+TYlaK2LDZ91AOzbUs3IK7Y2IySteYlOBt
+  EMrSzcjTADum/qQLqRKj8Wc/JNE2XkdpXsdZfycsV2rtqvGOUCoxbh50rEOSMC+5
+  WhJ5la/neyjk4DiCSnzPbnUaDkaEgAHk3jV6NMJXx3lLceP1Mh+hKZaSOte1UyJR
+  vUpwDZ2FS74T5o/W1Wc2LyJJtPOlx4Q6U6JweqlGzVhhf5jgc/AjFSUXvIBlKm2T
+  eGuurPN0159hsDh9h9MD0QhgRaSUUgbII+U46p2YiP3pXNqas+MsdOVm6oqhAgMB
+  AAEwDQYJKoZIhvcNAQELBQADggEBAKVgfnIIaq4x1Yqk9foobuqRMJ+xAWoSOr8b
+  pQp5tT0ZzjeYzmHoLcirzPkS+mKBfKHpAjwqCdSSnBheK76pagTrPqgXvAZnRWbO
+  6fNlnILJwv8sh8XZZi4DHd2AJ3B9bQrDgO7EeG2NbqNDUtEuen0R7u7lWHEXG0Lx
+  jQ8UHWHR9mfZSwK/eJ3ZZARmY3xlRC99CnbvavHPVrHEWuQxS/Ey+1/rsMykH/si
+  3BFuIFCF5OHEOLauBtfsmywjJVba0cTpKYrzqmONHZamIHxuYXxntOnLMEov8cj/
+  x4eordNlqNirAIi5idfd4slB/sfyk7zvdjizgpfdBzWQGui/IRU=
+  -----END CERTIFICATE-----
 
 # TODO remove this https://github.com/GSA/datagov-deploy/issues/2778
 solr_route: inventory-dev-solr.apps.internal

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -1,7 +1,7 @@
 app_name: inventory
 
-ckanext.saml2auth.entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-development-inventory
-
+ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-development-inventory
+ckanext__saml2auth__idp_metadata__local_path: config/login.sandbox.idp.xml
 
 # Number of application instances to run in cloud.gov
 instances: 1

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -1,6 +1,7 @@
 app_name: inventory
 
-ckanext.saml2auth.entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-production-inventory
+ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-production-inventory
+ckanext__saml2auth__idp_metadata__local_path: config/login.sandbox.idp.xml
 
 # Number of application instances to run in cloud.gov
 # TODO bump this to 2+ before launching https://github.com/GSA/datagov-deploy/issues/2788

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -1,11 +1,37 @@
 app_name: inventory
 
+ckanext.saml2auth.entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-production-inventory
+
 # Number of application instances to run in cloud.gov
 # TODO bump this to 2+ before launching https://github.com/GSA/datagov-deploy/issues/2788
 instances: 1
 
 routes:
   - route: inventory-prod-datagov.app.cloud.gov
+
+saml2_certificate: |
+  -----BEGIN CERTIFICATE-----
+  MIIDljCCAn4CCQCXgGGEjSiIojANBgkqhkiG9w0BAQsFADCBjDELMAkGA1UEBhMC
+  VVMxCzAJBgNVBAgMAkRDMRMwEQYDVQQHDApXYXNoaW5ndG9uMQwwCgYDVQQKDANH
+  U0ExDDAKBgNVBAsMA1RUUzEbMBkGA1UEAwwSaW52ZW50b3J5LmRhdGEuZ292MSIw
+  IAYJKoZIhvcNAQkBFhNkYXRhZ292aGVscEBnc2EuZ292MB4XDTIxMDIxODAyMDcw
+  M1oXDTIzMDIxODAyMDcwM1owgYwxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJEQzET
+  MBEGA1UEBwwKV2FzaGluZ3RvbjEMMAoGA1UECgwDR1NBMQwwCgYDVQQLDANUVFMx
+  GzAZBgNVBAMMEmludmVudG9yeS5kYXRhLmdvdjEiMCAGCSqGSIb3DQEJARYTZGF0
+  YWdvdmhlbHBAZ3NhLmdvdjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+  ALp+Ok9CNILECRIeA1767ldcrB3gh6lBVByA3FB63UycyaKAyahlte/uOz7i9ej3
+  SoGDOY8f4iRVlL/JP4S3+4eR3OGCa2qrrMOhjCGlYVzUYU+t9f6dRf4lfBWfFAv3
+  zW4mI+zVzaxX/bXVBYb6M9n2GNXTCQwNCqqQqgdpLstWVfiv1PU8X1nxT3CrVgwu
+  0AvfZuTuHCIuBtRzXq8yu8INS7eISloqcc+ou9+c7UUzXdyrY+3nATi+S4M5v9O7
+  Hy831yETEAtnaPQmNpxVL+LdUbVK6TIDcfNxmonfqnsG5kABvgrU+nf57d39iRPe
+  +mlM3NqRSWkfNwr0shm6cDUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEANCUWGk/E
+  s8gxAIgT9bOOfTZz9+ADT7nMuRdE8GdFq+fzS4SorreqYfFITqd+TUXaDrfsvQvz
+  0IjAIsXlWVhkkVTBXNhTkUth6bdVS/VUPBIrdlhSK9D7npWzhQhfK628T4HUhXb4
+  dx8WEIv1yu7xBmBfUwpE2uSCkPRN+xH1E61JryLqdvTrkc9CwxFU0qVDnCLSr3Ay
+  8W5ARzRUFpNpWS6kHVMQFraxvawjm3xJgR+JmeZZln79v3a44pKstKeELnINGoLT
+  FR8/D6wMVxy018ugn1/rA4DN6oEmDbFYrhzu3ELG7OkSNce82LKgqD3GdkCr/Dzc
+  FACe3zAui0XWNA==
+  -----END CERTIFICATE-----
 
 # TODO remove this https://github.com/GSA/datagov-deploy/issues/2778
 solr_route: inventory-prod-solr.apps.internal

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,6 +1,7 @@
 app_name: inventory
 
-ckanext.saml2auth.entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-staging-inventory
+ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-staging-inventory
+ckanext__saml2auth__idp_metadata__local_path: config/login.sandbox.idp.xml
 
 # Number of application instances to run in cloud.gov
 instances: 1

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,10 +1,35 @@
 app_name: inventory
 
+ckanext.saml2auth.entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-staging-inventory
+
 # Number of application instances to run in cloud.gov
 instances: 1
 
 routes:
   - route: inventory-stage-datagov.app.cloud.gov
+
+saml2_certificate: |
+  -----BEGIN CERTIFICATE-----
+  MIIDgjCCAmoCCQDwRWo8ECEF9jANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC
+  VVMxCzAJBgNVBAgMAkRDMRMwEQYDVQQHDApXYXNoaW5ndG9uMQwwCgYDVQQKDANH
+  U0ExDDAKBgNVBAsMA1RUUzERMA8GA1UEAwwIRGF0YS5nb3YxIjAgBgkqhkiG9w0B
+  CQEWE2RhdGFnb3ZoZWxwQGdzYS5nb3YwHhcNMjEwMjE4MDIwNjE1WhcNMjMwMjE4
+  MDIwNjE1WjCBgjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkRDMRMwEQYDVQQHDApX
+  YXNoaW5ndG9uMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzERMA8GA1UEAwwI
+  RGF0YS5nb3YxIjAgBgkqhkiG9w0BCQEWE2RhdGFnb3ZoZWxwQGdzYS5nb3YwggEi
+  MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1AwZactvYG9DYBA3MdngYMxs1
+  LvEy65GUK8nlqDuuSx9WYDdKNM2PJmbu1aLNeMllNhcvi/+sQeGvc3qGWWg1liyB
+  KIFiDt1jJyCX1YGidbOsKdKJ0p/5pDySG5Yk+vbpMUUn2wPhR/ORJ2GSSjIlQ2bS
+  kFv56RU7H/sRRUuXCT0n7D6gtqrYGnafnp02vQYFpUavRhtYAmTOKAvd6DKr/ts/
+  E1EqyGNGuvm20IAyBUJS7geyxhk0blmiwx0WOstuVdJM8BlU4NlgMWy1VLNZZeMU
+  pCUlkcyZ4+Uvm7LPYO9LcnN2npOqCOJJQf8OuuVjfm9RxTrWoPF79aaiXfBXAgMB
+  AAEwDQYJKoZIhvcNAQELBQADggEBAAJAB3vS9RZ/7UfYHVHgvqS3Dxy+GaFwp+rj
+  0Nckv4nCVVmLEQ9icex4D1+LwD5NGWxcoCLm+peRAtPFw55CzuF6kSLBFTLLKdYz
+  mWbF3yiyhWsuIGHTajyw1aOnHmVh5IGSIZZWGEFQVa1UtioSDVej3SAyVOazeO7Q
+  3wQSjtV6tQx64b3rvNsl8YuqahhP0w2Fm8Oz37DsoZ4VJPXAhnbsjkheYp92tltj
+  TbCWxu0SgIQXUdFw9lW1LPhhUCnvMf9p7UM+fal02FMFJOXV4kyJFoKbnx5UhyeH
+  5H534bh6UNxIFGe/8QuIZ8ZX6KRx3LVtwLYQY56r+uheU8j9v9s=
+  -----END CERTIFICATE-----
 
 # TODO remove this https://github.com/GSA/datagov-deploy/issues/2778
 solr_route: inventory-stage-solr.apps.internal


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2777

Adds configuration for SAML2 with Login.gov as the Identity Provider. Adds the
apt-buildpack in order to install xmlsec, a runtime dependency for pysaml2.

I went back and forth about keeping the certs in the repo or as configuration.
Since the key has to be supplied through configuration (user-provided service),
I opted to have the certificate be similar, although specified through the
manifest vars instead.

Also adds a helper function to cfstart.sh so there's less jq boilerplate to
typo.