### PR TITLE
Fix config error with cache_dir

### DIFF
--- a/cfstart.sh
+++ b/cfstart.sh
@@ -46,6 +46,7 @@ export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${CONFIG_DIR}/saml2_certificate.pem
 DS_RO_PASSWORD=$(vcap_get_service secrets .credentials.DS_RO_PASSWORD)
 export NEW_RELIC_LICENSE_KEY=$(vcap_get_service secrets .credentials.NEW_RELIC_LICENSE_KEY)
 export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION__SECRET)
+export CKAN___CACHE_DIR=${SHARED_DIR}/cache
 
 # ckan reads some environment variables... https://docs.ckan.org/en/2.8/maintaining/configuration.html#environment-variables
 export CKAN_SQLALCHEMY_URL=$(vcap_get_service db .credentials.uri)
@@ -65,6 +66,7 @@ export CKANEXT__S3FILESTORE__AWS_BUCKET_NAME=$(vcap_get_service s3 .credentials.
 
 # Write out any files and directories
 mkdir -p $CKAN_STORAGE_PATH
+mkdir -p $CKAN___CACHE_DIR
 echo "$SAML2_PRIVATE_KEY" | base64 -d > $CKANEXT__SAML2AUTH__KEY_FILE_PATH
 echo "$SAML2_CERTIFICATE" > $CKANEXT__SAML2AUTH__CERT_FILE_PATH
 

--- a/config/production.ini
+++ b/config/production.ini
@@ -24,7 +24,7 @@ port = 5000
 [app:main]
 use = egg:ckan
 full_stack = true
-cache_dir = /tmp/%(ckan.site_id)s/
+#cache_dir = $CKAN___CACHE_DIR
 beaker.session.key = ckan
 
 ckanext.datajson.inventory_links_enabled = True
@@ -49,7 +49,7 @@ app_instance_uuid = cf314c1a-1672-4451-9cb8-250629d6fdea
 # repoze.who config
 who.config_file = %(here)s/who.ini
 who.log_level = warning
-who.log_file = %(cache_dir)s/who_log.ini
+who.log_file = stdout
 # 50 minutes to match beaker.session.timeout
 who.timeout = 3000
 # who.httponly = True # DEFAULT True already


### PR DESCRIPTION
Now that site_id comes from the environment, it can't be used for interpolation.
Update the use of cache_dir within the config.