### PR TITLE
Update security and tests

### DIFF
--- a/ckanext-datagov_inventory/ckanext/datagov_inventory/plugin.py
+++ b/ckanext-datagov_inventory/ckanext/datagov_inventory/plugin.py
@@ -33,7 +33,6 @@ class Datagov_IauthfunctionsPlugin(plugins.SingletonPlugin):
     def get_auth_functions(self):
         return {'format_autocomplete': datagov_disallow_anonymous_access(),
                 'group_list': datagov_disallow_anonymous_access(),
-                'group_list_authz': datagov_disallow_anonymous_access(),
                 'license_list': datagov_disallow_anonymous_access(),
                 'member_roles_list': datagov_disallow_anonymous_access(),
                 'organization_list': datagov_disallow_anonymous_access(),
@@ -45,6 +44,8 @@ class Datagov_IauthfunctionsPlugin(plugins.SingletonPlugin):
                 'tag_list': datagov_disallow_anonymous_access(),
                 'tag_show': datagov_disallow_anonymous_access(),
                 'task_status_show': datagov_disallow_anonymous_access(),
+                'user_list': datagov_disallow_anonymous_access(),
+                'user_show': datagov_disallow_anonymous_access(),
                 'vocabulary_list': datagov_disallow_anonymous_access(),
                 'vocabulary_show': datagov_disallow_anonymous_access(),
                 }

--- a/ckanext-datagov_inventory/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
+++ b/ckanext-datagov_inventory/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
@@ -385,6 +385,34 @@ class TestDatagovInventoryAuth(object):
         })
 
 
+    def test_auth_user_list(self):
+        # Create test users and test data
+        self.setup_test_orgs_users()
+
+        self.assert_user_authorization('user_list', {
+            'gsa_admin': is_allowed,
+            'gsa_editor': is_allowed,
+            'gsa_member': is_allowed,
+            'doi_admin': is_allowed,
+            'doi_member': is_allowed,
+            'anonymous': is_denied
+        })
+
+
+    def test_auth_user_show(self):
+        # Create test users and test data
+        self.setup_test_orgs_users()
+
+        self.assert_user_authorization('user_show', {
+            'gsa_admin': is_allowed,
+            'gsa_editor': is_allowed,
+            'gsa_member': is_allowed,
+            'doi_admin': is_allowed,
+            'doi_member': is_allowed,
+            'anonymous': is_denied
+        })
+
+
     def test_auth_vocabulary_list(self):
         # Create test users and test data
         self.setup_test_orgs_users()

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -2,13 +2,13 @@ Babel==2.3.4
 Beaker==1.9.0
 bleach==3.3.0
 boto==2.49.0
-boto3==1.17.19
-botocore==1.20.19
+boto3==1.17.29
+botocore==1.20.29
 certifi==2020.12.5
 cffi==1.14.5
 chardet==3.0.4
 -e git+https://github.com/ckan/ckan.git@d200e583cf1e0cdacd6e375c78b88cf0dbf8bd47#egg=ckan
--e git+https://github.com/GSA/inventory-app.git@cc3b059f4085ebb48cdb1ab6012ce86dcaf32d4e#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
+-e git+https://github.com/GSA/inventory-app.git@c8e584fec9d2370155a594c94470b5308aab1319#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext_datajson
 ckanext-dcat-usmetadata==0.2.20
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@f0b75cf965e477a84f044885b27880782a48969c#egg=ckanext_googleanalyticsbasic

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -8,7 +8,7 @@ certifi==2020.12.5
 cffi==1.14.5
 chardet==3.0.4
 -e git+https://github.com/ckan/ckan.git@d200e583cf1e0cdacd6e375c78b88cf0dbf8bd47#egg=ckan
--e git+https://github.com/GSA/inventory-app.git@c8e584fec9d2370155a594c94470b5308aab1319#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
+-e git+https://github.com/GSA/inventory-app.git@065403a25ca12bdc949b34819c9358d7a469e9bc#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext_datajson
 ckanext-dcat-usmetadata==0.2.20
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@f0b75cf965e477a84f044885b27880782a48969c#egg=ckanext_googleanalyticsbasic

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -148,9 +148,8 @@ curl -f -X POST http://app:5000/api/action/resource_create  \
 }
 
 @test "data is inaccessible to public" {
-  run curl --fail --location --request GET 'http://app:5000/api/3/action/package_show?id=test-dataset-1'
-  # Validate output is 22, curl response for 403 (Forbidden)
-  [ "$status" -eq 22 ]
+  [ "404" == "$(curl --silent --output /dev/null --write-out %{http_code} http://app:5000/dataset/test-dataset-1)" ]
+  [ "403" == "$(curl --silent --output /dev/null --write-out %{http_code} http://app:5000/api/action/package_show?id=test-dataset-1)" ]
 }
 
 @test "Website display is working" {


### PR DESCRIPTION
Found error via New Relic alerts; dataset page was giving 500 error.
This cleans up group_list_authz; validates 404/403 in smoke tests, and adds some new route restrictions and tests related to https://github.com/GSA/datagov-deploy/issues/2824