### PR TITLE
update idp metadata 2021

### DIFF
--- a/config/login.sandbox.idp.xml
+++ b/config/login.sandbox.idp.xml
@@ -1,22 +1,21 @@
-<?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" ID="_50faff30-551d-0139-2a83-06a6af38cd4f" entityID="https://idp.int.identitysandbox.gov/api/saml">
+<EntityDescriptor ID="_51df0eb0-6e44-0139-ff8a-068564436685" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://idp.int.identitysandbox.gov/api/saml">
   <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
     <ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-      <ds:Reference URI="#_50faff30-551d-0139-2a83-06a6af38cd4f">
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+      <ds:Reference URI="#_51df0eb0-6e44-0139-ff8a-068564436685">
         <ds:Transforms>
-          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:Transform>
         </ds:Transforms>
-        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <ds:DigestValue>zbYoutkess5CHJAZtH9jguqY3rnlFJVc9IZZjmDhCoU=</ds:DigestValue>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"></ds:DigestMethod>
+        <ds:DigestValue>n0jMlmb46FlwPSErTDsvQGUQVlwpVVaYPYP0LVFqpP4=</ds:DigestValue>
       </ds:Reference>
     </ds:SignedInfo>
-    <ds:SignatureValue>Bcnqjisuu3kM/h9CJp6w9mwVYanB2q4PRYgFVGiUODEnpm+G0QjZlzqieBc5bdOzlxw0ka1ivtjXRMNJdZrainQWdNpuc1PYEF/umNE8fM7uHOCFA1NmBz7NoDVob63a+avOFOgzmH/Y/U3K8uVhGVS23q+ht9wppDuVBjboQydSC6UDAltQxSkKLFfFu4okb2HVrOoC2Rdan9YMZlwuEw/Rjugh8uVOFinJp2CehWxtqjmACUBlcLhFah/3VFPzY72eDgwhLZ7Op5lQdkNCCtgN12tyOaAyBlIy1w5agh+o+bptOVqgX7wu0UxV2Vev8M0g49QcwTcv7/Uyfm+u5w==</ds:SignatureValue>
+    <ds:SignatureValue>ybw0FYJtJN7CfYPQnnqqhLD0BoN590ozK+6zQkorjpPxobfwqfLiIvG1gFPimK81ix3xVKTBTtru60K63EIb3to89KkvTGYlSzNtrUuRKrFXgUHn5uMxmWsSrngCUVz+HhQJVg0QpjFPeatNKx3tXcyzcJYk9yfEXvxrc0aH+tMI9Js1igFHnzSJhCFBoIKKDgcvFWX2dietFRS1FtPuHO8bJnCswLyuZDGPh2EZQuDfbRDQp2mwnlFFep7ytSXzWRhGYxhufQIrFnYV7cQyWwkcH9VrolatW9CFnJcTKuSKt0oWMkMZ07ppyxr5v+XIm4KZNzDs8z+TFL9E9MFMkw==</ds:SignatureValue>
     <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
       <ds:X509Data>
-        <ds:X509Certificate>MIIDgDCCAmgCCQCBwmwOs+Ve3DANBgkqhkiG9w0BAQsFADCBgTELMAkGA1UEBhMCVVMxHTAbBgNVBAgMFERpc3RyaWN0IG9mIENvbHVtYmlhMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzESMBAGA1UECwwJTG9naW4uZ292MSMwIQYDVQQDDBpzZWN1cmUuaWRlbnRpdHlzYW5kYm94LmdvdjAeFw0yMDAzMTAxOTE0MzhaFw0yMTA0MDExOTE0MzhaMIGBMQswCQYDVQQGEwJVUzEdMBsGA1UECAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExDDAKBgNVBAoMA0dTQTEMMAoGA1UECwwDVFRTMRIwEAYDVQQLDAlMb2dpbi5nb3YxIzAhBgNVBAMMGnNlY3VyZS5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnpLbLzqL+7Xxa8HrxhX6DNBmpWvpldrT9Z8JKgFOjPuZZT1TPYpE6b2fL1M49SDCXudFssbgcX2BBGZsvZ96UGtKP0dz4Sy+RqWwSUBrptMwcayM5TGu0AW5kGDbb0ZC2M7jspHOZ1bdPdT3BGbyHIrCwBVwlyLSBeztACQTebmCaW5fioJnpigbMmGCpLm4zFYOLYmR1fEHgWNrw51rhxhb3OEODX5Wjp6F86oEqgJFmV4pq8ggL3qEKbNwpvm3QMUvQ1QmZh8bIBvp9BYcgTjCBFDYwTdR5KQpZHtSqdHjaxfDq3TJPUqVB+LMb9STjU/qKcvg/IbmwzQ0tDdzgQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBqcIhjTzbUOugSx7bkKwiS0qjpVgmZnvbb//eQeTmKuMquvy/DW1Lon9X6QBIvkwJMKMfgZVfTwV9C3h4kkPXnhZNt4HH0TPBqZZwprFoEOhqkjmx6jD5OdrVw/d505Q11lsb7yN7sOwJ0/Q26Ru3BA5sFCtAXM3TB9JGCZs2s/5Geut2Q6MTUMVutjsCPRRwpJ0ls22e5hxQRIuXjJf6tAOCVdt4YYbkYgcXYNe36N/zoZmnJOPZDtumCBcB9XsQw14G4kWHW38EaFpIY8yFt5p4k+8DbC6DTqgxOfYUWpmY9IGGS4A2Buwqh7rJcjv1g3f68Tz2vXphnfi5rmN4Y</ds:X509Certificate>
+        <ds:X509Certificate>MIID7TCCAtWgAwIBAgIUCethW2gYqC2N96czVCEaAkR/AiAwDQYJKoZIhvcNAQELBQAwgYUxCzAJBgNVBAYTAlVTMR0wGwYDVQQIDBREaXN0cmljdCBvZiBDb2x1bWJpYTETMBEGA1UEBwwKV2FzaGluZ3RvbjEMMAoGA1UECgwDR1NBMRIwEAYDVQQLDAlMb2dpbi5nb3YxIDAeBgNVBAMMF2ludC5pZGVudGl0eXNhbmRib3guZ292MB4XDTIxMDMwNTE5MDY1N1oXDTIyMDQwMTE5MDY1N1owgYUxCzAJBgNVBAYTAlVTMR0wGwYDVQQIDBREaXN0cmljdCBvZiBDb2x1bWJpYTETMBEGA1UEBwwKV2FzaGluZ3RvbjEMMAoGA1UECgwDR1NBMRIwEAYDVQQLDAlMb2dpbi5nb3YxIDAeBgNVBAMMF2ludC5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0OBtVKWm8J0vWLskFkkP9cTl1ZsgjGJFX4fbyhS0n21Q/20kFB3DPkHzzXLIiSUW0HSq9myrBoGiY0AET4OTN9n36aJ1miOM68Fklh/AWvHint25BEfmVLvjpCJqVmBriQS/SbwjEt6l03G7ZNV9o2pbRAjMUixysf4camHmZ6yEVWpa1Nb9BqZwk+wSLIBmCb4hYgCplkxT+NuHz0E2PonPBjr5Kr3in4NE2/B3YZl3JjBOwvt98/3HfuAWQbhvsWiAQdv9lI9UvHkc6WBEK1LAtDDjGC9IN70sx5M3DyP53DWGVzT+LdIgYgqw2kNoYLJPbPxI5G/8trFfaSNOXQIDAQABo1MwUTAdBgNVHQ4EFgQUAWvGpLiM7ZjZ6FYnlt7WVjk4740wHwYDVR0jBBgwFoAUAWvGpLiM7ZjZ6FYnlt7WVjk4740wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAGqOmAv+dtTms3quEteMtPeosyvHG7reRPSpZo2Z/oB46VYkGFd5Xf3zV9QkilX9fefDJH78WIU61nPIh0YMMVtyjO9SVcTE+2hpyvOcAc5UEZyhu3mUX7EiAHIIk2zrEIYTxGqGy8VxFpceeL8r9UjTbkKMgeL6i/mfK32eDRzt7+YR40KrG3iO4D4fOA0Mz6LW3jvuwLkLya7asl19QmA0BH+6s1JSzlhB+S71WmVbdHLqdp/DOIkVncFfXL5Cwz9Kv/gvpRUMbsawZ5IToZROskHZ2bcQ3XohBUce1G1cQQKuPOKqLbpV0UmJAFBkkmhPYCcKjHGjs2m8X08D6iw==</ds:X509Certificate>
       </ds:X509Data>
     </KeyInfo>
   </ds:Signature>
@@ -24,37 +23,32 @@
     <KeyDescriptor use="signing">
       <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <X509Data>
-          <X509Certificate>MIIDgDCCAmgCCQCBwmwOs+Ve3DANBgkqhkiG9w0BAQsFADCBgTELMAkGA1UEBhMCVVMxHTAbBgNVBAgMFERpc3RyaWN0IG9mIENvbHVtYmlhMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzESMBAGA1UECwwJTG9naW4uZ292MSMwIQYDVQQDDBpzZWN1cmUuaWRlbnRpdHlzYW5kYm94LmdvdjAeFw0yMDAzMTAxOTE0MzhaFw0yMTA0MDExOTE0MzhaMIGBMQswCQYDVQQGEwJVUzEdMBsGA1UECAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExDDAKBgNVBAoMA0dTQTEMMAoGA1UECwwDVFRTMRIwEAYDVQQLDAlMb2dpbi5nb3YxIzAhBgNVBAMMGnNlY3VyZS5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnpLbLzqL+7Xxa8HrxhX6DNBmpWvpldrT9Z8JKgFOjPuZZT1TPYpE6b2fL1M49SDCXudFssbgcX2BBGZsvZ96UGtKP0dz4Sy+RqWwSUBrptMwcayM5TGu0AW5kGDbb0ZC2M7jspHOZ1bdPdT3BGbyHIrCwBVwlyLSBeztACQTebmCaW5fioJnpigbMmGCpLm4zFYOLYmR1fEHgWNrw51rhxhb3OEODX5Wjp6F86oEqgJFmV4pq8ggL3qEKbNwpvm3QMUvQ1QmZh8bIBvp9BYcgTjCBFDYwTdR5KQpZHtSqdHjaxfDq3TJPUqVB+LMb9STjU/qKcvg/IbmwzQ0tDdzgQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBqcIhjTzbUOugSx7bkKwiS0qjpVgmZnvbb//eQeTmKuMquvy/DW1Lon9X6QBIvkwJMKMfgZVfTwV9C3h4kkPXnhZNt4HH0TPBqZZwprFoEOhqkjmx6jD5OdrVw/d505Q11lsb7yN7sOwJ0/Q26Ru3BA5sFCtAXM3TB9JGCZs2s/5Geut2Q6MTUMVutjsCPRRwpJ0ls22e5hxQRIuXjJf6tAOCVdt4YYbkYgcXYNe36N/zoZmnJOPZDtumCBcB9XsQw14G4kWHW38EaFpIY8yFt5p4k+8DbC6DTqgxOfYUWpmY9IGGS4A2Buwqh7rJcjv1g3f68Tz2vXphnfi5rmN4Y</X509Certificate>
+          <X509Certificate>MIID7TCCAtWgAwIBAgIUCethW2gYqC2N96czVCEaAkR/AiAwDQYJKoZIhvcNAQELBQAwgYUxCzAJBgNVBAYTAlVTMR0wGwYDVQQIDBREaXN0cmljdCBvZiBDb2x1bWJpYTETMBEGA1UEBwwKV2FzaGluZ3RvbjEMMAoGA1UECgwDR1NBMRIwEAYDVQQLDAlMb2dpbi5nb3YxIDAeBgNVBAMMF2ludC5pZGVudGl0eXNhbmRib3guZ292MB4XDTIxMDMwNTE5MDY1N1oXDTIyMDQwMTE5MDY1N1owgYUxCzAJBgNVBAYTAlVTMR0wGwYDVQQIDBREaXN0cmljdCBvZiBDb2x1bWJpYTETMBEGA1UEBwwKV2FzaGluZ3RvbjEMMAoGA1UECgwDR1NBMRIwEAYDVQQLDAlMb2dpbi5nb3YxIDAeBgNVBAMMF2ludC5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0OBtVKWm8J0vWLskFkkP9cTl1ZsgjGJFX4fbyhS0n21Q/20kFB3DPkHzzXLIiSUW0HSq9myrBoGiY0AET4OTN9n36aJ1miOM68Fklh/AWvHint25BEfmVLvjpCJqVmBriQS/SbwjEt6l03G7ZNV9o2pbRAjMUixysf4camHmZ6yEVWpa1Nb9BqZwk+wSLIBmCb4hYgCplkxT+NuHz0E2PonPBjr5Kr3in4NE2/B3YZl3JjBOwvt98/3HfuAWQbhvsWiAQdv9lI9UvHkc6WBEK1LAtDDjGC9IN70sx5M3DyP53DWGVzT+LdIgYgqw2kNoYLJPbPxI5G/8trFfaSNOXQIDAQABo1MwUTAdBgNVHQ4EFgQUAWvGpLiM7ZjZ6FYnlt7WVjk4740wHwYDVR0jBBgwFoAUAWvGpLiM7ZjZ6FYnlt7WVjk4740wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAGqOmAv+dtTms3quEteMtPeosyvHG7reRPSpZo2Z/oB46VYkGFd5Xf3zV9QkilX9fefDJH78WIU61nPIh0YMMVtyjO9SVcTE+2hpyvOcAc5UEZyhu3mUX7EiAHIIk2zrEIYTxGqGy8VxFpceeL8r9UjTbkKMgeL6i/mfK32eDRzt7+YR40KrG3iO4D4fOA0Mz6LW3jvuwLkLya7asl19QmA0BH+6s1JSzlhB+S71WmVbdHLqdp/DOIkVncFfXL5Cwz9Kv/gvpRUMbsawZ5IToZROskHZ2bcQ3XohBUce1G1cQQKuPOKqLbpV0UmJAFBkkmhPYCcKjHGjs2m8X08D6iw==</X509Certificate>
         </X509Data>
       </KeyInfo>
     </KeyDescriptor>
     <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
-    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress</NameIDFormat>
-    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.int.identitysandbox.gov/api/saml/auth2020"/>
-    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.int.identitysandbox.gov/api/saml/auth2020"/>
-  </IDPSSODescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat><SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.int.identitysandbox.gov/api/saml/auth2021"/><SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.int.identitysandbox.gov/api/saml/auth2021"/></IDPSSODescriptor>
   <AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <X509Data>
-          <X509Certificate>MIIDgDCCAmgCCQCBwmwOs+Ve3DANBgkqhkiG9w0BAQsFADCBgTELMAkGA1UEBhMCVVMxHTAbBgNVBAgMFERpc3RyaWN0IG9mIENvbHVtYmlhMQwwCgYDVQQKDANHU0ExDDAKBgNVBAsMA1RUUzESMBAGA1UECwwJTG9naW4uZ292MSMwIQYDVQQDDBpzZWN1cmUuaWRlbnRpdHlzYW5kYm94LmdvdjAeFw0yMDAzMTAxOTE0MzhaFw0yMTA0MDExOTE0MzhaMIGBMQswCQYDVQQGEwJVUzEdMBsGA1UECAwURGlzdHJpY3Qgb2YgQ29sdW1iaWExDDAKBgNVBAoMA0dTQTEMMAoGA1UECwwDVFRTMRIwEAYDVQQLDAlMb2dpbi5nb3YxIzAhBgNVBAMMGnNlY3VyZS5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnpLbLzqL+7Xxa8HrxhX6DNBmpWvpldrT9Z8JKgFOjPuZZT1TPYpE6b2fL1M49SDCXudFssbgcX2BBGZsvZ96UGtKP0dz4Sy+RqWwSUBrptMwcayM5TGu0AW5kGDbb0ZC2M7jspHOZ1bdPdT3BGbyHIrCwBVwlyLSBeztACQTebmCaW5fioJnpigbMmGCpLm4zFYOLYmR1fEHgWNrw51rhxhb3OEODX5Wjp6F86oEqgJFmV4pq8ggL3qEKbNwpvm3QMUvQ1QmZh8bIBvp9BYcgTjCBFDYwTdR5KQpZHtSqdHjaxfDq3TJPUqVB+LMb9STjU/qKcvg/IbmwzQ0tDdzgQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBqcIhjTzbUOugSx7bkKwiS0qjpVgmZnvbb//eQeTmKuMquvy/DW1Lon9X6QBIvkwJMKMfgZVfTwV9C3h4kkPXnhZNt4HH0TPBqZZwprFoEOhqkjmx6jD5OdrVw/d505Q11lsb7yN7sOwJ0/Q26Ru3BA5sFCtAXM3TB9JGCZs2s/5Geut2Q6MTUMVutjsCPRRwpJ0ls22e5hxQRIuXjJf6tAOCVdt4YYbkYgcXYNe36N/zoZmnJOPZDtumCBcB9XsQw14G4kWHW38EaFpIY8yFt5p4k+8DbC6DTqgxOfYUWpmY9IGGS4A2Buwqh7rJcjv1g3f68Tz2vXphnfi5rmN4Y</X509Certificate>
+          <X509Certificate>MIID7TCCAtWgAwIBAgIUCethW2gYqC2N96czVCEaAkR/AiAwDQYJKoZIhvcNAQELBQAwgYUxCzAJBgNVBAYTAlVTMR0wGwYDVQQIDBREaXN0cmljdCBvZiBDb2x1bWJpYTETMBEGA1UEBwwKV2FzaGluZ3RvbjEMMAoGA1UECgwDR1NBMRIwEAYDVQQLDAlMb2dpbi5nb3YxIDAeBgNVBAMMF2ludC5pZGVudGl0eXNhbmRib3guZ292MB4XDTIxMDMwNTE5MDY1N1oXDTIyMDQwMTE5MDY1N1owgYUxCzAJBgNVBAYTAlVTMR0wGwYDVQQIDBREaXN0cmljdCBvZiBDb2x1bWJpYTETMBEGA1UEBwwKV2FzaGluZ3RvbjEMMAoGA1UECgwDR1NBMRIwEAYDVQQLDAlMb2dpbi5nb3YxIDAeBgNVBAMMF2ludC5pZGVudGl0eXNhbmRib3guZ292MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0OBtVKWm8J0vWLskFkkP9cTl1ZsgjGJFX4fbyhS0n21Q/20kFB3DPkHzzXLIiSUW0HSq9myrBoGiY0AET4OTN9n36aJ1miOM68Fklh/AWvHint25BEfmVLvjpCJqVmBriQS/SbwjEt6l03G7ZNV9o2pbRAjMUixysf4camHmZ6yEVWpa1Nb9BqZwk+wSLIBmCb4hYgCplkxT+NuHz0E2PonPBjr5Kr3in4NE2/B3YZl3JjBOwvt98/3HfuAWQbhvsWiAQdv9lI9UvHkc6WBEK1LAtDDjGC9IN70sx5M3DyP53DWGVzT+LdIgYgqw2kNoYLJPbPxI5G/8trFfaSNOXQIDAQABo1MwUTAdBgNVHQ4EFgQUAWvGpLiM7ZjZ6FYnlt7WVjk4740wHwYDVR0jBBgwFoAUAWvGpLiM7ZjZ6FYnlt7WVjk4740wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAGqOmAv+dtTms3quEteMtPeosyvHG7reRPSpZo2Z/oB46VYkGFd5Xf3zV9QkilX9fefDJH78WIU61nPIh0YMMVtyjO9SVcTE+2hpyvOcAc5UEZyhu3mUX7EiAHIIk2zrEIYTxGqGy8VxFpceeL8r9UjTbkKMgeL6i/mfK32eDRzt7+YR40KrG3iO4D4fOA0Mz6LW3jvuwLkLya7asl19QmA0BH+6s1JSzlhB+S71WmVbdHLqdp/DOIkVncFfXL5Cwz9Kv/gvpRUMbsawZ5IToZROskHZ2bcQ3XohBUce1G1cQQKuPOKqLbpV0UmJAFBkkmhPYCcKjHGjs2m8X08D6iw==</X509Certificate>
         </X509Data>
       </KeyInfo>
     </KeyDescriptor>
     <Organization>
-      <OrganizationName xml:lang="en">18F</OrganizationName>
-      <OrganizationDisplayName xml:lang="en">18F</OrganizationDisplayName>
-      <OrganizationURL xml:lang="en">http://18f.gsa.gov</OrganizationURL>
+      <OrganizationName xml:lang="en">login.gov</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">login.gov</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">https://login.gov</OrganizationURL>
     </Organization>
-    <ContactPerson contactType="technical"/>
-    <AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.int.identitysandbox.gov/api/saml/attributes"/>
-    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
-    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress</NameIDFormat>
+    <ContactPerson contactType="technical"></ContactPerson><AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.int.identitysandbox.gov/api/saml/attributes"/><NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
   </AttributeAuthorityDescriptor>
   <Organization>
-    <OrganizationName xml:lang="en">18F</OrganizationName>
-    <OrganizationDisplayName xml:lang="en">18F</OrganizationDisplayName>
-    <OrganizationURL xml:lang="en">http://18f.gsa.gov</OrganizationURL>
+    <OrganizationName xml:lang="en">login.gov</OrganizationName>
+    <OrganizationDisplayName xml:lang="en">login.gov</OrganizationDisplayName>
+    <OrganizationURL xml:lang="en">https://login.gov</OrganizationURL>
   </Organization>
-  <ContactPerson contactType="technical"/>
+  <ContactPerson contactType="technical"></ContactPerson>
 </EntityDescriptor>


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/3004

IdP metadata updated using https://idp.int.identitysandbox.gov/api/saml/metadata2021.
SP certificate has another 2 years life, not updated this time.