### PR TITLE
restart application regularly

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -1,0 +1,27 @@
+---
+name: restart application
+
+on:
+  schedule:
+    - cron: '7,15,22,37,52 * * * *'
+
+jobs:
+  restart-staging:
+    name: restart (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    env:
+      APP_URL: https://inventory-stage-datagov.app.cloud.gov
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: restart
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: restart --strategy rolling
+          org: gsa-datagov
+          space: staging
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: smoke test
+        run: bin/smoke.sh


### PR DESCRIPTION
Testing staging, then will implement for production.
Related to https://github.com/GSA/datagov-deploy/issues/1644
Will not run unless it is on the default branch, see [docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule).