### PR TITLE
remove inventory login from default err login page

### DIFF
--- a/ckanext/datagov_inventory/templates/error_document_template.html
+++ b/ckanext/datagov_inventory/templates/error_document_template.html
@@ -9,7 +9,7 @@
         <article class="module">
             <div class="module-content">
                 <h2>You are not authorized to perform this action.</h2>
-                <p>If you a government user, you are either not allowed to perform this action or you need to {% link_for _('Log in'), named_route='user.login' %}.</p>
+                <p>If you a government user, you are either not allowed to perform this action or you need to login.</p>
                 <p>If you are looking for data please go to <a href='https://catalog.data.gov/dataset'>catalog.data.gov</a>.</p>
             </div>
         </article>


### PR DESCRIPTION
Part of [this work](https://github.com/GSA/datagov-deploy/issues/2796)