### PR TITLE
Set publishers for local build for metadata form

### DIFF
--- a/seed.sh
+++ b/seed.sh
@@ -144,3 +144,13 @@ curl -X POST \
   "name": "test-dataset-1",
   "program_code": "010:001"
 }'
+
+echo Adding publishers to metadata form
+# check if file exists, if not get it from github
+if [ -f "/opt/inventory-app/publishers.test.csv" ]; then
+  echo Publisher file already exists
+else
+  wget https://raw.githubusercontent.com/GSA/ckanext-dcat_usmetadata/main/ckanext/dcat_usmetadata/publishers.test.csv
+fi
+# add publisher file
+/usr/lib/ckan/bin/paster --plugin=ckanext-dcat_usmetadata publishers-import /opt/inventory-app/publishers.test.csv -c $CKAN_INI


### PR DESCRIPTION
Found while working on [this ticket](https://github.com/GSA/datagov-deploy/issues/1486).

When you call `make up-with-data` the seed script will grab the publishers csv (if it doesn't already exist) and run the appropriate command to update the list.