### PR TITLE
use fork to patch datastore-search-sql

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -7,7 +7,7 @@ botocore==1.20.29
 certifi==2020.12.5
 cffi==1.14.5
 chardet==3.0.4
--e git+https://github.com/ckan/ckan.git@d200e583cf1e0cdacd6e375c78b88cf0dbf8bd47#egg=ckan
+-e git+https://github.com/GSA/ckan.git@7158eb9d34e7c3ad5aef30fa0f00e520cacfc4e4#egg=ckan
 -e git+https://github.com/GSA/inventory-app.git@065403a25ca12bdc949b34819c9358d7a469e9bc#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext_datajson
 ckanext-dcat-usmetadata==0.2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/ckan/ckan.git@ckan-2.8.7#egg=ckan
+-e git+https://github.com/GSA/ckan.git@patch/datastore-search-sql#egg=ckan
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/USMetadata.git@ckan-2-8#egg=ckanext-usmetadata
 -e git+https://github.com/GSA/ckanext-datajson.git@master#egg=ckanext-datajson


### PR DESCRIPTION
Use a fork to patch https://github.com/GSA/datagov-deploy/issues/2661 before upstream official release.