### PR TITLE
disable server header in gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN $CKAN_HOME/bin/pip install -r $REQUIREMENTS_FILE
 COPY entrypoint-docker.sh /
 ENTRYPOINT ["/entrypoint-docker.sh"]
 
+COPY config/gunicorn.conf.py $CKAN_CONFIG/
 COPY config/server_start.sh $CKAN_CONFIG/
 
 CMD ["/bin/bash"]

--- a/config/gunicorn.conf.py
+++ b/config/gunicorn.conf.py
@@ -1,0 +1,4 @@
+# gunicorn prior to version 20.1.0 discloses "server" header
+# https://github.com/GSA/datagov-deploy/issues/2826
+import gunicorn
+gunicorn.SERVER_SOFTWARE = ''

--- a/config/server_start.sh
+++ b/config/server_start.sh
@@ -7,4 +7,4 @@ if test -f "$DIR/.env"; then
 fi
 
 # Run web application
-exec newrelic-admin run-program gunicorn --worker-class gevent --paste $CKAN_INI "$@"
+exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@"


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/2826

I was not able to remove the server header. We can either give it a unique value such as "undisclosed-some-uuid", or leave it blank. I chose the latter. So now the response header looks like
```
...
server:
...
```