### PR TITLE
upgrade ckan core to 2.8.8

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -8,7 +8,7 @@ certifi==2020.12.5
 cffi==1.14.5
 chardet==3.0.4
 -e git+https://github.com/ckan/ckan.git@e5105334fbdfd312412da4e05221ce0588dc2dfd#egg=ckan
--e git+git@github.com:GSA/inventory-app.git@3dbadd68608036744100e866dde1f735c94408f2#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
+-e git+https://github.com/GSA/inventory-app.git@3dbadd68608036744100e866dde1f735c94408f2#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext_datajson
 ckanext-dcat-usmetadata==0.2.20
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@f0b75cf965e477a84f044885b27880782a48969c#egg=ckanext_googleanalyticsbasic

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -2,13 +2,13 @@ Babel==2.3.4
 Beaker==1.9.0
 bleach==3.3.0
 boto==2.49.0
-boto3==1.17.62
-botocore==1.20.62
+boto3==1.17.76
+botocore==1.20.76
 certifi==2020.12.5
 cffi==1.14.5
 chardet==3.0.4
--e git+https://github.com/GSA/ckan.git@7158eb9d34e7c3ad5aef30fa0f00e520cacfc4e4#egg=ckan
--e git+https://github.com/GSA/inventory-app.git@a34f94430145443ac3123f37d0ff3251095ca1dd#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
+-e git+https://github.com/ckan/ckan.git@e5105334fbdfd312412da4e05221ce0588dc2dfd#egg=ckan
+-e git+git@github.com:GSA/inventory-app.git@3dbadd68608036744100e866dde1f735c94408f2#egg=ckanext_datagov_inventory&subdirectory=ckanext-datagov_inventory
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext_datajson
 ckanext-dcat-usmetadata==0.2.20
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic@f0b75cf965e477a84f044885b27880782a48969c#egg=ckanext_googleanalyticsbasic
@@ -28,7 +28,7 @@ FormEncode==1.3.1
 funcsigs==1.0.2
 futures==3.3.0
 gevent==21.1.2
-greenlet==1.0.0
+greenlet==1.1.0
 gunicorn==19.10.0
 html5lib==1.0.1
 idna==2.7
@@ -56,7 +56,7 @@ pbr==1.10.0
 polib==1.0.7
 psycopg2==2.7.3.2
 pycparser==2.20
-Pygments @ git+https://github.com/GSA/pygments.git@f9f800a18ed795f6d9579f0acf934f8103a964bf
+Pygments @ git+https://github.com/GSA/pygments.git@f6ccbc8c73b6b0a3c86ba7f1cfc36ac98ff5f122
 Pylons==0.9.7
 pyOpenSSL==20.0.1
 pyparsing==2.4.7
@@ -84,7 +84,7 @@ SQLAlchemy==1.1.11
 sqlalchemy-migrate==0.10.0
 sqlparse==0.2.2
 Tempita==0.5.2
-typing==3.7.4.3
+typing==3.10.0.0
 tzlocal==1.3
 unicodecsv==0.14.1
 urllib3==1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
--e git+https://github.com/GSA/ckan.git@patch/datastore-search-sql#egg=ckan
+-e git+https://github.com/ckan/ckan.git@ckan-2.8.8#egg=ckan
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/USMetadata.git@ckan-2-8#egg=ckanext-usmetadata
--e git+https://github.com/GSA/ckanext-datajson.git@master#egg=ckanext-datajson
+-e git+https://github.com/GSA/ckanext-datajson.git@main#egg=ckanext-datajson
 -e git+https://github.com/keitaroinc/ckanext-saml2auth.git@ckan-2.8#egg=ckanext-saml2auth
 -e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob
 ckanext-dcat-usmetadata~=0.2


### PR DESCRIPTION
ckan 2.8.8 has the [datastore-search-sql](https://github.com/GSA/datagov-deploy/issues/2661) fix

Post deployment task
- [ ] remove https://github.com/GSA/ckan.git@patch/datastore-search-sql