### PR TITLE
increase gunicorn timeout and add more workers

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,7 +2,7 @@ FROM bats/bats
 
 RUN apk add curl jq
 
-COPY tests/ /tests/
+COPY tests/ /code/tests/
 
 # bats/bats uses bats as the entrypoint
-CMD ["-r", "/tests"]
+CMD ["-r", "/code/tests"]

--- a/config/development.ini
+++ b/config/development.ini
@@ -14,7 +14,9 @@
 [DEFAULT]
 
 # WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
-debug=true
+## debug has to be false to have multiple gunicorn workers
+## https://github.com/GSA/datagov-deploy/issues/3359
+debug = false
 
 [server:main]
 use = egg:Paste#http

--- a/config/server_start.sh
+++ b/config/server_start.sh
@@ -3,4 +3,4 @@
 DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 # Run web application
-exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@"
+exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@" --timeout 120

--- a/config/server_start.sh
+++ b/config/server_start.sh
@@ -3,4 +3,4 @@
 DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 # Run web application
-exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@" --timeout 120
+exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@" --timeout 120 --workers 3


### PR DESCRIPTION
1.
We see this error when inventory is taking more than 30 seconds to generate a large data.json file. 
```
[CRITICAL] WORKER TIMEOUT (pid:1716)
Error - <type 'exceptions.SystemExit'>
```
Changing gunicorn timeout from default 30 seconds to 120.

2.
resolve https://github.com/GSA/datagov-deploy/issues/3359 by adding more workers