### PR TITLE
use new test path "/code/tests"

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,7 +2,7 @@ FROM bats/bats
 
 RUN apk add curl jq
 
-COPY tests/ /tests/
+COPY tests/ /code/tests/
 
 # bats/bats uses bats as the entrypoint
-CMD ["-r", "/tests"]
+CMD ["-r", "/code/tests"]


### PR DESCRIPTION
Fix this error:
```
test_1 | Error: Test file "/code/tests" does not exist
```