### PR TITLE
Remove new relic log file configuration

### DIFF
--- a/env_file
+++ b/env_file
@@ -2,7 +2,6 @@
 NEW_RELIC_LICENSE_KEY=
 NEW_RELIC_APP_NAME=inventory-next
 NEW_RELIC_MONITOR_MODE=false
-NEW_RELIC_LOG=/var/log/new_relic.log
 NEW_RELIC_LOG_LEVEL=info
 NEW_RELIC_HOST=gov-collector.newrelic.com
 


### PR DESCRIPTION
This does not work on inventory-app, it logs an exception and rolls back to stdout and stderr logging. That is how it should be configured for cloud.gov