### PR TITLE
Revert "increase gunicorn timeout and add more workers"

### DIFF
--- a/config/development.ini
+++ b/config/development.ini
@@ -14,9 +14,7 @@
 [DEFAULT]
 
 # WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
-## debug has to be false to have multiple gunicorn workers
-## https://github.com/GSA/datagov-deploy/issues/3359
-debug = false
+debug=true
 
 [server:main]
 use = egg:Paste#http

--- a/config/server_start.sh
+++ b/config/server_start.sh
@@ -3,4 +3,4 @@
 DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 # Run web application
-exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@" --timeout 120 --workers 3
+exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@"


### PR DESCRIPTION
Reverts GSA/inventory-app#336

This caused cascading failures (app fails to start properly, many alerts). We need to test in the dev environment before continuing. Might need more memory, might be something else entirely.