### PR TITLE
try again, set 2 gunicorn workers

### DIFF
--- a/config/development.ini
+++ b/config/development.ini
@@ -14,7 +14,9 @@
 [DEFAULT]
 
 # WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
-debug=true
+## debug has to be false to have multiple gunicorn workers
+## https://github.com/GSA/datagov-deploy/issues/3359
+debug = false
 
 [server:main]
 use = egg:Paste#http

--- a/config/server_start.sh
+++ b/config/server_start.sh
@@ -3,4 +3,4 @@
 DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 # Run web application
-exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@"
+exec newrelic-admin run-program gunicorn -c "$DIR/gunicorn.conf.py" --worker-class gevent --paste $CKAN_INI "$@" --timeout 120 --workers 2


### PR DESCRIPTION
Try #336 again. 
It seems 2 is a magic number to set workers. 3 will makes all three threads consuming 100% CPU. 2 has no effect on the CPU usage. 