### PR TITLE
Update buildpack to use cloud.gov

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,7 +10,7 @@ applications:
     instances: ((instances))
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
-      - https://github.com/cloudfoundry/python-buildpack
+      - python-buildpack
     routes: ((routes))
     services:
       - ((app_name))-db


### PR DESCRIPTION
Use cloud.gov managed python buildpack, so we are notified to restage when new releases are available.