### PR TITLE
Pin ckanext-datajson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e git+https://github.com/ckan/ckan.git@ckan-2.8.9#egg=ckan
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/USMetadata.git@ckan-2-8#egg=ckanext-usmetadata
--e git+https://github.com/GSA/ckanext-datajson.git@main#egg=ckanext-datajson
+-e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext-datajson
 -e git+https://github.com/keitaroinc/ckanext-saml2auth.git@ckan-2.8#egg=ckanext-saml2auth
 -e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob
 ckanext-dcat-usmetadata~=0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 -e git+https://github.com/ckan/ckan.git@ckan-2.8.9#egg=ckan
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/USMetadata.git@ckan-2-8#egg=ckanext-usmetadata
+# Pin datajson extension to working CKAN2.8 commit
+# https://github.com/GSA/datagov-deploy/issues/3365
 -e git+https://github.com/GSA/ckanext-datajson.git@4ca1ca31cfcc23d6610c13693049fcfc83696d08#egg=ckanext-datajson
 -e git+https://github.com/keitaroinc/ckanext-saml2auth.git@ckan-2.8#egg=ckanext-saml2auth
 -e git+https://github.com/GSA/webob.git@ckan-patch#egg=webob


### PR DESCRIPTION
Pin ckanext-datajson on ckan2.8 to avoid breaking changes.

Related to https://github.com/GSA/datagov-deploy/issues/3365