### PR TITLE
Ignore files from main when switching branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,66 @@ src/
 *.csv
 vendor/*
 vars.yml
+secrets.json
 
-node_modules/
+.ropeproject
+node_modules
+bower_components
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+sdist/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Sphinx documentation
+docs/_build/
+
+# Cypress
+e2e/cypress/videos/*
+e2e/cypress/screenshots/*
+e2e/cypress/results/output.xml
+e2e/cypress/downloads
+# Commit testing resource(s) csv
+!e2e/cypress/fixtures/*.csv
+
+# Future
+*.bak
+
+# Vim
+*.swp
+
+# Specific to ignore main branch stuff that should be ignored on fcs
 ckanext/
 ckanext_datagov_inventory.egg-info/
 e2e/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ src/
 *.csv
 vendor/*
 vars.yml
+
+node_modules/
+ckanext/
+ckanext_datagov_inventory.egg-info/
+e2e/
+config/__pycache__


### PR DESCRIPTION
VS Code always goes crazy trying to track node_modules and other folders that shouldn't be tracked when switching between branches, this should ignore that extra stuff.