### PR TITLE
Update CKAN 2.9.4

### DIFF
--- a/e2e/cypress/integration/ckan_extensions.spec.js
+++ b/e2e/cypress/integration/ckan_extensions.spec.js
@@ -3,7 +3,7 @@ describe('CKAN Extensions', () => {
     it('Uses CKAN 2.9', () => {
         cy.request('/api/action/status_show').should((response) => {
             expect(response.body).to.have.property('success', true);
-            expect(response.body.result).to.have.property('ckan_version', '2.9.3');
+            expect(response.body.result).to.have.property('ckan_version', '2.9.4');
         });
     })
 

--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ckan/ckan.git@ckan-2.9.3#egg=ckan
+git+https://github.com/ckan/ckan.git@ckan-2.9.4#egg=ckan
 -e git+https://github.com/GSA/ckanext-googleanalyticsbasic#egg=ckanext-googleanalyticsbasic
 -e git+https://github.com/GSA/ckanext-usmetadata.git@main#egg=ckanext-usmetadata
 # TODO https://github.com/GSA/datagov-deploy/issues/2794

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ botocore==1.21.45
 certifi==2021.5.30
 cffi==1.14.6
 chardet==3.0.4
-ckan @ git+https://github.com/ckan/ckan.git@e8b7970423e2cce9731441edd13f7fcfd3be58e9
+ckan @ git+https://github.com/ckan/ckan.git@6731c5a821a6a5f4bdaa20f4e793e0b6ba44f823
 -e git+https://github.com/GSA/ckanext-datajson.git@a5d8c9458a7efe955c31b90eeac1e7797881d014#egg=ckanext_datajson
 ckanext-dcat-usmetadata==0.3.0
 ckanext-envvars==0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ckanext-envvars==0.0.1
 ckanext-s3filestore @ git+https://github.com/keitaroinc/ckanext-s3filestore.git@82a63639b0f54f65496661c7120ed85461eade37
 ckanext-saml2auth @ git+https://github.com/keitaroinc/ckanext-saml2auth.git@454412fb32a8ba3676e08a948959c6c5be684b6f
 -e git+https://github.com/GSA/ckanext-usmetadata.git@0382cf70550867188336a9dda382bf0aa8b933a1#egg=ckanext_usmetadata
--e git+https://github.com/ckan/ckanext-xloader.git@ca97113912cc70fcb2c8377e1b3b43168c4cfc65#egg=ckanext_xloader
+-e git+https://github.com/ckan/ckanext-xloader.git@7423f1da96173b777c0e4aa40e208981c297f0ca#egg=ckanext_xloader
 ckantoolkit==0.0.4
 click==7.1.2
 cryptography==3.4.8


### PR DESCRIPTION
Tests fail on CKAN2.9.4.

Resource fails to load via the API, gives a 500 error.

See upstream issue for more details: https://github.com/ckan/ckan/issues/6447

Do not merge unless all tests pass.