### PR TITLE
Save Cypress video and screenshots

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -35,6 +35,14 @@ jobs:
         run: make test
       - name: test extension
         run: make test_extension
+      - name: cypress-artifacs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-artifacts
+          path: |
+            ./e2e/cypress/screenshots/
+            ./e2e/cypress/videos/
 
   vendor:
     name: vendor dependencies


### PR DESCRIPTION
This should load the artifacts as a zip to the failing github action to review if needed. Cypress log output is very vague, this will help greatly in debugging future failures.

Copy of https://github.com/GSA/catalog.data.gov/pull/362