### PR TITLE
Update cfsetup to .profile, add sysadmin-users

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -65,7 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - lint
-      - test
       - vendor
     env:
       APP_URL: https://inventory-dev-datagov.app.cloud.gov

--- a/.profile
+++ b/.profile
@@ -43,6 +43,9 @@ export NEW_RELIC_LICENSE_KEY=$(vcap_get_service secrets .credentials.NEW_RELIC_L
 export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION__SECRET)
 export CKAN___CACHE_DIR=${SHARED_DIR}/cache
 
+# Get sysadmins list by a user-provided-service per environment
+export CKANEXT__SAML2AUTH__SYSADMINS_LIST=$(echo $VCAP_SERVICES | jq --raw-output ".[][] | select(.name == \"sysadmin-users\") | .credentials.CKANEXT__SAML2AUTH__SYSADMINS_LIST")
+
 # ckan reads some environment variables... https://docs.ckan.org/en/2.8/maintaining/configuration.html#environment-variables
 export CKAN_SQLALCHEMY_URL=$(vcap_get_service db .credentials.uri)
 export CKAN___BEAKER__SESSION__URL=${CKAN_SQLALCHEMY_URL}
@@ -78,5 +81,3 @@ DATASTORE_URL=$CKAN_DATASTORE_WRITE_URL DS_RO_USER=$DS_RO_USER DS_RO_PASSWORD=$D
 # Run migrations
 # paster --plugin=ckan db upgrade -c config/production.ini
 ckan -c $CKAN_INI db upgrade
-
-exec $@

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./cfsetup.sh config/server_start.sh
+web: ./config/server_start.sh

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,6 +18,7 @@ applications:
       - ((app_name))-s3
       - ((app_name))-redis
       - ((app_name))-secrets
+      - sysadmin-users
     timeout: 120
     health-check-http-endpoint: /api/action/status_show
     env:


### PR DESCRIPTION
sysadmin-users is service used by catalog, and is shared.
Already exists, just needs to be linked (manifest will handle that)
Change cfsetup to .profile for automatic setup on cf run-task,
and update procfile accordingly.