### PR TITLE
Fix Gunicorn start

### DIFF
--- a/.profile
+++ b/.profile
@@ -81,7 +81,7 @@ export SOLR_COLLECTION=ckan
 export CKAN_SOLR_URL=$CKAN_SOLR_BASE_URL/solr/$SOLR_COLLECTION
 
 # Edit the config file to validate debug is off and utilizes the correct port
-export CKAN_INI=config/ckan.ini
+export CKAN_INI="${HOME}/config/ckan.ini"
 # ckan config-tool $CKAN_INI -s server:main -e port=${PORT}
 ckan config-tool $CKAN_INI --section DEFAULT --edit debug=false
 

--- a/config/ckan.ini
+++ b/config/ckan.ini
@@ -24,7 +24,6 @@ port = 8080
 [app:main]
 use = egg:ckan
 #cache_dir = $CKAN___CACHE_DIR
-
 beaker.session.key = ckan
 
 ckanext.datajson.inventory_links_enabled = True

--- a/config/ckan.ini
+++ b/config/ckan.ini
@@ -23,8 +23,12 @@ port = 8080
 
 [app:main]
 use = egg:ckan
-full_stack = true
 #cache_dir = $CKAN___CACHE_DIR
+
+## Development settings
+ckan.devserver.host = localhost
+ckan.devserver.port = 5000
+
 beaker.session.key = ckan
 
 ckanext.datajson.inventory_links_enabled = True

--- a/config/ckan.ini
+++ b/config/ckan.ini
@@ -25,10 +25,6 @@ port = 8080
 use = egg:ckan
 #cache_dir = $CKAN___CACHE_DIR
 
-## Development settings
-ckan.devserver.host = localhost
-ckan.devserver.port = 5000
-
 beaker.session.key = ckan
 
 ckanext.datajson.inventory_links_enabled = True


### PR DESCRIPTION
Fix for following issue,
<details>
  <summary>error from logs</summary>

```
   2021-12-21T16:06:47.85-0500 [APP/PROC/WEB/0] ERR [2021-12-21 21:06:47 +0000] [13] [INFO] Starting gunicorn 20.1.0
   2021-12-21T16:06:47.85-0500 [APP/PROC/WEB/0] ERR [2021-12-21 21:06:47 +0000] [13] [INFO] Using worker: sync
   2021-12-21T16:06:47.86-0500 [APP/PROC/WEB/0] ERR [2021-12-21 21:06:47 +0000] [236] [INFO] Booting worker with pid: 236
   2021-12-21T16:06:48.12-0500 [APP/PROC/WEB/0] ERR 2021-12-21 21:06:48,127 INFO  [ckan.cli] Using configuration file config/ckan.ini
   2021-12-21T16:06:48.12-0500 [APP/PROC/WEB/0] ERR 2021-12-21 21:06:48,127 INFO  [ckan.config.environment] Loading static files from public
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR [2021-12-21 21:06:48 +0000] [236] [ERROR] Exception in worker process
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR Traceback (most recent call last):
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "/home/vcap/deps/1/python/lib/python3.8/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR     worker.init_process()
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR     self.load_wsgi()
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "/home/vcap/deps/1/python/lib/python3.8/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi

   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR     self.wsgi = self.app.wsgi()
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "/home/vcap/deps/1/python/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi

   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR     return self.load_wsgiapp()
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "/home/vcap/deps/1/python/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR     return util.import_app(self.app_uri)
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "/home/vcap/deps/1/python/lib/python3.8/site-packages/gunicorn/util.py", line 359, in import_app
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "/home/vcap/deps/1/python/lib/python3.8/importlib/__init__.py", line 127, in import_module
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "<frozen importlib._bootstrap_external>", line 843, in exec_module
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR   File "/home/vcap/app/config/wsgi.py", line 15, in <module>
   2021-12-21T16:06:48.53-0500 [APP/PROC/WEB/0] ERR [2021-12-21 21:06:48 +0000] [236] [INFO] Worker exiting (pid: 236)
```

</details>