### PR TITLE
package_show for anonymous user

### DIFF
--- a/ckanext/datagov_inventory/plugin.py
+++ b/ckanext/datagov_inventory/plugin.py
@@ -2,10 +2,12 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic
 from ckan.model import User
-from ckan.common import _
+from ckan.common import _, request as ckan_request
 from ckan.logic.auth import get_resource_object
+from ckan.logic.auth.get import package_show
 import ckan.authz as authz
 import logging
+import re
 
 
 log = logging.getLogger(__name__)
@@ -64,6 +66,26 @@ def inventory_resource_show(context, data_dict):
             return {'success': True}
 
 
+@toolkit.auth_allow_anonymous_access
+def inventory_package_show(context, data_dict):
+    model = context['model']
+    user = User.by_name(context.get('user'))
+    pkg = model.Package.get(data_dict.get('id', None))
+
+    # package_show appears to be needed to download package resources.
+    # but we dont want direct package_show call open to anonymous user.
+    # only for download url matching /dataset/*/resource/*/download/*
+    url_pattern = r"^/dataset/[0-9a-f-]{36}/resource/[0-9a-f-]{36}/download/.*"
+    re_pattern = re.compile(url_pattern)
+    if user is None:
+        if not pkg.private and re_pattern.match(ckan_request.full_path):
+            return {'success': True}
+        else:
+            return {'success': False}
+    else:
+        return package_show(context, data_dict)
+
+
 class Datagov_IauthfunctionsPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IConfigurer)
@@ -76,7 +98,7 @@ class Datagov_IauthfunctionsPlugin(plugins.SingletonPlugin):
                 'organization_list': datagov_disallow_anonymous_access(),
                 'package_list': datagov_disallow_anonymous_access(),
                 'package_search': datagov_disallow_anonymous_access(),
-                'package_show': datagov_disallow_anonymous_access(),
+                'package_show': inventory_package_show,
                 'resource_show': inventory_resource_show,
                 'site_read': datagov_disallow_anonymous_access(),
                 'tag_list': datagov_disallow_anonymous_access(),

--- a/ckanext/datagov_inventory/plugin.py
+++ b/ckanext/datagov_inventory/plugin.py
@@ -5,7 +5,6 @@ from ckan.model import User
 from ckan.common import _
 from ckan.logic.auth import get_resource_object
 import ckan.authz as authz
-# import ckan.authz as authz
 import logging
 
 
@@ -72,7 +71,6 @@ class Datagov_IauthfunctionsPlugin(plugins.SingletonPlugin):
     def get_auth_functions(self):
         return {'format_autocomplete': datagov_disallow_anonymous_access(),
                 'group_list': datagov_disallow_anonymous_access(),
-                'group_list_authz': datagov_disallow_anonymous_access(),
                 'license_list': datagov_disallow_anonymous_access(),
                 'member_roles_list': datagov_disallow_anonymous_access(),
                 'organization_list': datagov_disallow_anonymous_access(),
@@ -84,6 +82,8 @@ class Datagov_IauthfunctionsPlugin(plugins.SingletonPlugin):
                 'tag_list': datagov_disallow_anonymous_access(),
                 'tag_show': datagov_disallow_anonymous_access(),
                 'task_status_show': datagov_disallow_anonymous_access(),
+                'user_list': datagov_disallow_anonymous_access(),
+                'user_show': datagov_disallow_anonymous_access(),
                 'vocabulary_list': datagov_disallow_anonymous_access(),
                 'vocabulary_show': datagov_disallow_anonymous_access(),
                 }

--- a/ckanext/datagov_inventory/templates/error_document_template.html
+++ b/ckanext/datagov_inventory/templates/error_document_template.html
@@ -9,7 +9,7 @@
         <article class="module">
             <div class="module-content">
                 <h2>You are not authorized to perform this action.</h2>
-                <p>If you a government user, you are either not allowed to perform this action or you need to login.</p>
+                <p>If you are a government user, you are either not allowed to perform this action or you need to login.</p>
                 <p>If you are looking for data please go to <a href='https://catalog.data.gov/dataset'>catalog.data.gov</a>.</p>
             </div>
         </article>

--- a/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
+++ b/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
@@ -330,6 +330,32 @@ class TestDatagovInventoryAuth(object):
             'anonymous': is_denied
         })
 
+    def test_auth_user_list(self):
+        # Create test users and test data
+        self.setup_test_orgs_users()
+
+        self.assert_user_authorization('user_list', {
+            'gsa_admin': is_allowed,
+            'gsa_editor': is_allowed,
+            'gsa_member': is_allowed,
+            'doi_admin': is_allowed,
+            'doi_member': is_allowed,
+            'anonymous': is_denied
+        })
+
+    def test_auth_user_show(self):
+        # Create test users and test data
+        self.setup_test_orgs_users()
+
+        self.assert_user_authorization('user_show', {
+            'gsa_admin': is_allowed,
+            'gsa_editor': is_allowed,
+            'gsa_member': is_allowed,
+            'doi_admin': is_allowed,
+            'doi_member': is_allowed,
+            'anonymous': is_denied
+        })
+
     def test_auth_vocabulary_list(self):
         # Create test users and test data
         self.setup_test_orgs_users()

--- a/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
+++ b/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
@@ -438,7 +438,7 @@ class TestDatagovInventoryAuth(FunctionalTestBase):
 
         self.create_datasets()
         context = {'user': None, 'model': model}
-        data_dict = {'id': self.dataset_public['id']}
+        data_dict = {'id': self.dataset_private['id']}
         test_url = '/dataset/'+'0'*36+'/resource/'+'0'*36+'/download/1'
         with self.app.flask_app.test_request_context(test_url):
             assert inventory_package_show(context,

--- a/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
+++ b/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
@@ -1,6 +1,5 @@
 """Tests for datagov_inventory plugin.py."""
 
-from builtins import object
 from pytest import raises as assert_raises
 import pytest
 
@@ -431,7 +430,8 @@ class TestDatagovInventoryAuth(FunctionalTestBase):
         data_dict = {'id': self.dataset_public['id']}
         test_url = '/dataset/'+'0'*36+'/resource/'+'0'*36+'/download/1'
         with self.app.flask_app.test_request_context(test_url):
-            assert inventory_package_show(context, data_dict) == {'success': True}
+            assert inventory_package_show(context,
+                                          data_dict) == {'success': True}
 
     def test_resource_show_request_private_dataset(self):
         self.app = self._get_test_app()
@@ -441,4 +441,5 @@ class TestDatagovInventoryAuth(FunctionalTestBase):
         data_dict = {'id': self.dataset_public['id']}
         test_url = '/dataset/'+'0'*36+'/resource/'+'0'*36+'/download/1'
         with self.app.flask_app.test_request_context(test_url):
-            assert inventory_package_show(context, data_dict) == {'success': False}
+            assert inventory_package_show(context,
+                                          data_dict) == {'success': False}

--- a/e2e/cypress/integration/dataset.spec.js
+++ b/e2e/cypress/integration/dataset.spec.js
@@ -57,5 +57,23 @@ describe('Dataset', () => {
         cy.get('a[href*="ckan_resource.csv"]').click()
         // check downloaded file matches uploaded file header
         cy.task('isExistFile', 'ckan_resource.csv').should('contain', 'for,testing,purposes');
-    })
+    });
+
+    it('Download resource file', () => {
+        // Test download as anonymous user
+
+        cy.visit('/dataset/test-dataset-1')
+        // Hide flask debug toolbar
+        cy.get('#flHideToolBarButton').click();
+        // Open resource dropdown
+        cy.get('.dropdown-toggle').click();
+        // Download resource file
+        cy.get('a[href*="ckan_resource.csv"]').click().should('have.attr', 'href').then((href) => {
+            cy.logout();
+            cy.request(href).then((response) => {
+              cy.writeFile('cypress/downloads/ckan_resource2.csv', response.body)
+            });
+            cy.task('isExistFile', 'ckan_resource2.csv').should('contain', 'for,testing,purposes');
+        });
+    });
 })


### PR DESCRIPTION
open package_show to anonymous user only to download resource.

For https://github.com/GSA/datagov-deploy/issues/3619

`package_show` appears to be needed to download package resources.
Without it user sees 404 when downloading resource.
But we don't want direct package_show call open to anonymous user.
Only for download url matching `/dataset/*/resource/*/download/*`