### PR TITLE
Adjust memory quota

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,6 +16,7 @@ applications:
       - ((app_name))-solr
       - sysadmin-users
     timeout: 120
+    memory: ((memory_quota))
     health-check-http-endpoint: /api/action/status_show
     command: ./config/server_start.sh
     env:

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -5,6 +5,7 @@ ckanext__saml2auth__idp_metadata__local_path: config/login.sandbox.idp.xml
 
 # Number of application instances to run in cloud.gov
 instances: 1
+memory_quota: 300M
 
 new_relic_app_name: inventory (development)
 new_relic_monitor_mode: false

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -5,6 +5,7 @@ ckanext__saml2auth__idp_metadata__local_path: config/login.production.idp.xml
 
 # Number of application instances to run in cloud.gov
 instances: 2
+memory_quota: 500M
 
 new_relic_app_name: inventory
 new_relic_monitor_mode: true

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -5,6 +5,7 @@ ckanext__saml2auth__idp_metadata__local_path: config/login.sandbox.idp.xml
 
 # Number of application instances to run in cloud.gov
 instances: 2
+memory_quota: 300M
 
 new_relic_app_name: inventory (staging)
 new_relic_monitor_mode: true


### PR DESCRIPTION
Due to ongoing struggles with memory quota, this reduces the requirement in staging since we don't have much traffic there,  prod doesn't use much more and averages below 300M, but some margin of safety is added to ensure operation.