### PR TITLE
pin jinja2 in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ factory-boy==2.12.0
 # Flask-DebugToolbar==0.11.0
 httpretty
 ipdb==0.13.4
+Jinja2==3.0.1
 mock==2.0.0
 pycodestyle==2.5.0
 pip-tools==5.1.2


### PR DESCRIPTION
otherwise we saw this error when `make up`
```
ImportError: cannot import name 'escape' from 'jinja2'
```
and leads to `make test` getting stuck and ci check failure. 