### PR TITLE
Temporary fix of organization page URL generation bug

### DIFF
--- a/ckanext/datagov_inventory/templates/organization/snippets/organization_item.html
+++ b/ckanext/datagov_inventory/templates/organization/snippets/organization_item.html
@@ -1,0 +1,51 @@
+{#
+Renders a media item for a organization. This should be used in a list.
+
+organization - A organization dict.
+
+Example:
+
+    <ul class="media-grid">
+      {% for organization in organizations %}
+        {% snippet "organization/snippets/organization_item.html", organization=organization %}
+      {% endfor %}
+    </ul>
+#}
+{% set url = h.url_for("organization.read", id=organization.name) %}
+{% block item %}
+<li class="media-item">
+  {% block item_inner %}
+  {% block image %}
+    <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-fluid media-image">
+  {% endblock %}
+  {% block title %}
+    <h2 class="media-heading">{{ organization.display_name }}</h2>
+  {% endblock %}
+  {% block description %}
+    {% if organization.description %}
+      <p class="media-description">{{ h.markdown_extract(organization.description, extract_length=80) }}</p>
+    {% endif %}
+  {% endblock %}
+  {% block datasets %}
+    {% if organization.package_count %}
+      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
+    {% else %}
+      <span class="count">{{ _('0 Datasets') }}</span>
+    {% endif %}
+  {% endblock %}
+  {% block capacity %}
+    {% if show_capacity and organization.capacity %}
+    <p><span class="label label-default">{{ h.roles_translated().get(organization.capacity, organization.capacity) }}</span></p>
+    {% endif %}
+  {% endblock %}
+  {% block link %}
+  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
+    <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
+  </a>
+  {% endblock %}
+  {% endblock %}
+</li>
+{% endblock %}
+{% if position is divisibleby 3 %}
+  <li class="clearfix js-hide"></li>
+{% endif %}


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3614

The organization read url_for function appends extra arguments to it and it causes problems loading an organization.

This is a solution; doesn't mean that it is the correct solution.