### PR TITLE
specify health-check-type

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -18,6 +18,7 @@ applications:
     timeout: 120
     memory: ((memory_quota))
     disk_quota: ((disk_quota))
+    health-check-type: http
     health-check-http-endpoint: /api/action/status_show
     command: ./config/server_start.sh
     env:


### PR DESCRIPTION
could this be the reason for problematic inventory health check, causing 404/502 periodically?