### PR TITLE
Update v8 cloudgov to main action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
       - name: smoke test
         run: bin/smoke.sh
       - name: deploy-proxy
-        uses: cloud-gov/cg-cli-tools@cli-v8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: cf push inventory-proxy --vars-file vars.staging.yml --strategy rolling
           cf_org: gsa-datagov


### PR DESCRIPTION
Deploy to staging failed: https://github.com/GSA/inventory-app/runs/6356550802?check_suite_focus=true

This should use `main`, all others already do.