### PR TITLE
Pin markupsafe

### DIFF
--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -86,3 +86,4 @@ Unidecode==1.0.22
 
 # Other pinned dependencies
 itsdangerous==2.0.1
+MarkupSafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ jsonschema==2.4.0
 lxml==4.9.1
 Mako==1.2.1
 Markdown==2.6.7
-MarkupSafe==2.1.1
+MarkupSafe==2.0.1
 messytables==0.15.2
 newrelic==7.14.0.177
 nose==1.3.7


### PR DESCRIPTION
Fix required for python3.7 (apparently?)