### PR TITLE
Run publisher update after deploy

### DIFF
--- a/.github/workflows/update_publishers.yml
+++ b/.github/workflows/update_publishers.yml
@@ -3,9 +3,10 @@ name: Update Inventory Publishers List
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["deploy"]
+    types:
+      - completed
 
 jobs:
   update-publishers-staging:


### PR DESCRIPTION
While a PR was merged to deploy new publisher (https://github.com/GSA/inventory-app/pull/469), the action ran before the deploy and the changes weren't applied. This should fix that and run after the deploy, and all the logic should remain the same.