### PR TITLE
Never deployed the correct command for publishers

### DIFF
--- a/.github/workflows/update_publishers.yml
+++ b/.github/workflows/update_publishers.yml
@@ -34,7 +34,7 @@ jobs:
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
-            cf run-task inventory --command 'ckan publishers-import config/data/inventory_publishers.csv' --name 'update-publishers'
+            cf run-task inventory --command 'ckan dcat-usmetadata import-publishers config/data/inventory_publishers.csv' --name 'update-publishers'
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -67,7 +67,7 @@ jobs:
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
-            cf run-task inventory --command 'ckan publishers-import config/data/inventory_publishers.csv' --name 'update-publishers'
+            cf run-task inventory --command 'ckan dcat-usmetadata import-publishers config/data/inventory_publishers.csv' --name 'update-publishers'
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}


### PR DESCRIPTION
https://github.com/gsa/ckanext-dcat_usmetadata#publishers-import

See manual deployment check here: https://github.com/GSA/inventory-app/actions/runs/2707591358

And see logs from manual deployment check here:

```
2022-07-20T14:52:39.25-0600 [APP/TASK/update-publishers/0] OUT 2022-07-20 20:52:39,257 DEBUG [ckanext.s3filestore.uploader] Bucket REDACTED found!
   2022-07-20T14:52:39.84-0600 [APP/TASK/update-publishers/0] OUT Updated publishers for 'department-of-the-treasury'
```