### PR TITLE
Pin cf cli to v7

### DIFF
--- a/.github/workflows/update_publishers.yml
+++ b/.github/workflows/update_publishers.yml
@@ -31,7 +31,9 @@ jobs:
           echo "UPDATE_PUBLISHERS=True" >> $GITHUB_ENV
       - name: Update Publishers
         if: ${{ env.UPDATE_PUBLISHERS }}
-        uses: cloud-gov/cg-cli-tools@main
+        # pinned to cf7 until --wait is available for run-task on cf8...
+        # https://github.com/cloudfoundry/cli/issues/2238
+        uses: cloud-gov/cg-cli-tools@cli-v7
         with:
           command: |
             cf run-task inventory --command 'ckan dcat-usmetadata import-publishers config/data/inventory_publishers.csv' --wait --name 'update-publishers'
@@ -64,7 +66,9 @@ jobs:
           echo "UPDATE_PUBLISHERS=True" >> $GITHUB_ENV
       - name: Update Publishers
         if: ${{ env.UPDATE_PUBLISHERS }}
-        uses: cloud-gov/cg-cli-tools@main
+        # pinned to cf7 until --wait is available for run-task on cf8...
+        # https://github.com/cloudfoundry/cli/issues/2238
+        uses: cloud-gov/cg-cli-tools@cli-v7
         with:
           command: |
             cf run-task inventory --command 'ckan dcat-usmetadata import-publishers config/data/inventory_publishers.csv' --wait --name 'update-publishers'


### PR DESCRIPTION
To utilize `--wait` feature.

Forgot about this not working on cf cli v8

See failure: https://github.com/GSA/inventory-app/runs/7681503982?check_suite_focus=true

cc @hkdctol , most recent changes did not deploy.