### PR TITLE
testing restart work-around on staging

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -7,34 +7,39 @@ on:
     - cron: '7/15 * * * *'
 
 jobs:
-  # restart-staging:
-  #   concurrency: staging
-  #   name: restart (staging)
-  #   environment: staging
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     APP_URL: https://inventory-stage-datagov.app.cloud.gov
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v2
-  #     - name: restart
-  #       uses: cloud-gov/cg-cli-tools@main
-  #       with:
-  #         command: cf restart inventory --strategy rolling
-  #         cf_org: gsa-datagov
-  #         cf_space: staging
-  #         cf_username: ${{secrets.CF_SERVICE_USER}}
-  #         cf_password: ${{secrets.CF_SERVICE_AUTH}}
-  #     - name: smoke test
-  #       run: bin/smoke.sh
-  #     - name: restart proxy
-  #       uses: cloud-gov/cg-cli-tools@main
-  #       with:
-  #         command: cf restart inventory-proxy --strategy rolling
-  #         cf_org: gsa-datagov
-  #         cf_space: staging
-  #         cf_username: ${{secrets.CF_SERVICE_USER}}
-  #         cf_password: ${{secrets.CF_SERVICE_AUTH}}
+  restart-staging:
+    concurrency: staging
+    name: restart (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    env:
+      APP_URL: https://inventory-stage-datagov.app.cloud.gov
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: restart
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: cf restart inventory --strategy rolling
+          cf_org: gsa-datagov
+          cf_space: staging
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: smoke test
+        run: bin/smoke.sh
+      - name: restart proxy
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf scale inventory -i 1 &&
+            sleep 5 &&
+            cf restart inventory-proxy --strategy rolling' &&
+            sleep 5;
+            cf scale inventory -i 2
+          cf_org: gsa-datagov
+          cf_space: staging
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
 
   # restart-prod:
   #   concurrency: production


### PR DESCRIPTION
use this command to test a work-around so we can restart app on production without getting stuck. The restart issue is discussed in a [slack thread](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1660679897477429).
```
cf scale inventory -i 1 &&
sleep 5 &&
cf restart inventory-proxy --strategy rolling' &&
sleep 5;
cf scale inventory -i 2
```