### PR TITLE
Bump github action versions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: ['3.x']
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: test
         run: make build test
       - name: test extension
         run: make test_extension
       - name: cypress-artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-artifacts
@@ -49,10 +49,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: vendor dependencies
         run: ./vendor-requirements.sh build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: python-vendored
           path: vendor/
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -87,7 +87,7 @@ jobs:
       APP_URL: https://inventory-dev-datagov.app.cloud.gov
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: python-vendored

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: vendor dependencies
         run: ./vendor-requirements.sh build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: python-vendored
           path: vendor/
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -50,7 +50,7 @@ jobs:
       APP_URL: https://inventory-stage-datagov.app.cloud.gov
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: python-vendored
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -101,7 +101,7 @@ jobs:
       APP_URL: https://inventory.data.gov
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: python-vendored

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -16,7 +16,7 @@ jobs:
       APP_URL: https://inventory-stage-datagov.app.cloud.gov
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: restart
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -50,7 +50,7 @@ jobs:
       APP_URL: https://inventory.data.gov
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: restart
         uses: cloud-gov/cg-cli-tools@main
         with:


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/4005

See latest versions of [download-artifact](https://github.com/actions/download-artifact/tags) and [actions/checkout](https://github.com/actions/checkout/tags)