### PR TITLE
Feature/ignore 404 nr

### DIFF
--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -1,0 +1,26 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+error_collector.expected_classes = werkzeug.exceptions:Forbidden

--- a/manifest.yml
+++ b/manifest.yml
@@ -31,6 +31,7 @@ applications:
       NEW_RELIC_APP_NAME: ((app_name))-((space_name))
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
+      NEW_RELIC_CONFIG_FILE: /home/vcap/app/config/newrelic.ini
       SAML2_CERTIFICATE: ((saml2_certificate))
 
   - name: ((app_name))-proxy


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3991

Could use validation in staging. Should note that we will no longer be alerted if resource pages are blocked (and intended to be public), however this causes so much noise we might need to make a special case/alert for resource pages being available.