### PR TITLE
ignore werkzeug.exceptions:MethodNotAllowed

### DIFF
--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -23,4 +23,4 @@
 # Here are the settings that are common to all environments.
 
 [newrelic]
-error_collector.expected_classes = werkzeug.exceptions:Forbidden
+error_collector.expected_classes = werkzeug.exceptions:Forbidden werkzeug.exceptions:MethodNotAllowed


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/3635

Ignore error MethodNotAllowed.