### PR TITLE
On the latest version of Python 3.11 🤯 

### DIFF
--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -1,6 +1,6 @@
 FROM cloudfoundry/cflinuxfs3
 # Specify Python version
-ARG PY_VERSION=python3.10
+ARG PY_VERSION=python3.11
 
 # Go where the app files are
 RUN cd ~vcap/app

--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -4,12 +4,11 @@ FROM cloudfoundry/cflinuxfs3
 RUN cd ~vcap/app
 
 # Install any packaged dependencies for our vendored packages
-# Install python3.7 because that's what the buildpak uses
 RUN apt-get -y update
 RUN apt install software-properties-common -y
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install swig build-essential python-dev libssl-dev python3.8
+RUN apt-get -y install swig build-essential python-dev libssl-dev python3.9
 
 # Install PIP
 RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-RUN python3.8 /tmp/get-pip.py
+RUN python3.9 /tmp/get-pip.py

--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -5,9 +5,10 @@ RUN cd ~vcap/app
 
 # Install any packaged dependencies for our vendored packages
 RUN apt-get -y update
-RUN apt-get -y install software-properties-common python3-distutils
+RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install swig build-essential python-dev libssl-dev python3.9
+RUN apt-get -y install swig build-essential python-dev libssl-dev python3.9-distutils
+RUN apt-get -y install python3.9
 
 # Install PIP
 RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py

--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -1,4 +1,6 @@
 FROM cloudfoundry/cflinuxfs3
+# Specify Python version
+ARG PY_VERSION=python3.10
 
 # Go where the app files are
 RUN cd ~vcap/app
@@ -7,9 +9,9 @@ RUN cd ~vcap/app
 RUN apt-get -y update
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install swig build-essential python-dev libssl-dev python3.9-distutils
-RUN apt-get -y install python3.9
+RUN apt-get -y install swig build-essential python-dev libssl-dev ${PY_VERSION}-distutils
+RUN apt-get -y install ${PY_VERSION}
 
 # Install PIP
 RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-RUN python3.9 /tmp/get-pip.py
+RUN ${PY_VERSION} /tmp/get-pip.py

--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -5,7 +5,7 @@ RUN cd ~vcap/app
 
 # Install any packaged dependencies for our vendored packages
 RUN apt-get -y update
-RUN apt install software-properties-common -y
+RUN apt-get -y install software-properties-common python3-distutils
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get -y install swig build-essential python-dev libssl-dev python3.9
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10.x
+python-3.11.x

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.x
+python-3.10.x

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.x
+python-3.9.x


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3876
- https://github.com/GSA/catalog.data.gov/pull/654

References:
- https://askubuntu.com/questions/1239829/modulenotfounderror-no-module-named-distutils-util
- https://linuxize.com/post/how-to-install-python-3-9-on-ubuntu-20-04/
- https://www.python.org/doc/versions/
- https://github.com/cloudfoundry/python-buildpack/releases/tag/v1.8.3