### PR TITLE
Pin to 3.10 since buildpack is not up to date yet

### DIFF
--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -1,6 +1,6 @@
 FROM cloudfoundry/cflinuxfs3
 # Specify Python version
-ARG PY_VERSION=python3.11
+ARG PY_VERSION=python3.10
 
 # Go where the app files are
 RUN cd ~vcap/app


### PR DESCRIPTION
Related to
- #504 
- #503 
- #502 

We need to vendor for the specific version we are using 😞 