### PR TITLE
Revert to Python 3.9 😭 

### DIFF
--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -1,6 +1,6 @@
 FROM cloudfoundry/cflinuxfs3
 # Specify Python version
-ARG PY_VERSION=python3.10
+ARG PY_VERSION=python3.9
 
 # Go where the app files are
 RUN cd ~vcap/app

--- a/Dockerfile.vendor
+++ b/Dockerfile.vendor
@@ -1,6 +1,6 @@
 FROM cloudfoundry/cflinuxfs3
 # Specify Python version
-ARG PY_VERSION=python3.9
+ARG PY_VERSION=python3.10
 
 # Go where the app files are
 RUN cd ~vcap/app

--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -36,7 +36,7 @@ Flask-Babel==1.0.0
 flask-multistatic==1.0
 Jinja2==2.11.3
 PyJWT==2.4.0              # Upgraded to pass security scans
-Markdown==2.6.7
+Markdown==3.4.1           # Upgraded https://github.com/GSA/data.gov/issues/4056
 passlib==1.7.3
 pastedeploy==2.0.1        # manually kept - remove when #4802 is complete
 pathtools==0.1.2          # via watchdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ json-table-schema==0.2.1
 jsonschema==2.4.0
 lxml==4.9.1
 Mako==1.2.2
-Markdown==2.6.7
+Markdown==3.4.1
 MarkupSafe==2.0.1
 messytables==0.15.2
 newrelic==8.1.0.180

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.x
+python-3.10.x

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10.x
+python-3.9.x

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.x
+python-3.9.x


### PR DESCRIPTION
Related to
- #504 
- #505 
- #503 
- #502 
- https://github.com/GSA/data.gov/issues/4056
- https://github.com/GSA/data.gov/issues/4057

Important Notes:
- Markdown was upgraded to support underlying Python architecture