### PR TITLE
Remove duplicate setuptools

### DIFF
--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -53,8 +53,6 @@ repoze.who==2.3
 requests==2.25.0
 Routes==1.13
 rq==1.0
-# pin setuptools until we get python buildpack 1.7.58
-setuptools==65.1.1 #to fix transitive dep issue: https://github.com/cloudfoundry/python-buildpack/issues/574
 simplejson==3.18.0 # ckan 2.9.5 requires 3.10.0 only
 # Following can be ignored: https://github.com/ckan/ckan/pull/4450
 # sqlalchemy-migrate==0.12.0


### PR DESCRIPTION
Related to
- https://github.com/GSA/inventory-app/actions/runs/3703877847/jobs/6275840758
- https://github.com/GSA/data.gov/issues/4125

The pin should no longer be necessary.  The GH Action should not have failed in the way that it did.