### PR TITLE
apply same fixes from catalog to inventory for local solr startup

### DIFF
--- a/solr/local_setup.sh
+++ b/solr/local_setup.sh
@@ -6,4 +6,7 @@ set -e
 /app/solr/solr_setup.sh
 
 # Start solr
-su -c "init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -Dsolr.lock.type=simple" -m solr
+su -c "\
+    export PATH=$PATH:/opt/docker-solr/scripts/:/opt/solr/bin/;\
+    init-var-solr; precreate-core ckan /tmp/ckan_config; chown -R 8983:8983 /var/solr/data; solr-fg -Dsolr.lock.type=simple \
+" -m solr


### PR DESCRIPTION
fixes this error on startup:

```
inventory-app-solr-1       | 
inventory-app-solr-1       | sh: 1: init-var-solr: not found
inventory-app-solr-1       | sh: 1: precreate-core: not found
inventory-app-solr-1       | sh: 1: solr-fg: not found
inventory-app-solr-1 exited with code 127
inventory-app-ckan-1       | nc: bad address 'solr'
....
inventory-app-ckan-1       | nc: bad address 'solr'
```