### PR TITLE
datajson changes to fix download errors

### DIFF
--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -9,7 +9,7 @@ git+https://github.com/keitaroinc/ckanext-s3filestore.git#egg=ckanext-s3filestor
 
 ckanext-googleanalyticsbasic
 ckanext-usmetadata>=0.2.5
-ckanext-datajson>=0.1.10
+ckanext-datajson>=0.1.15
 ckanext-dcat-usmetadata~=0.3.8
 ckanext-envvars>=0.0.2
 newrelic

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2022.12.7
 cffi==1.15.1
 chardet==3.0.4
 ckan==2.9.8
-ckanext-datajson==0.1.14
+ckanext-datajson==0.1.15
 ckanext-dcat-usmetadata==0.3.8
 ckanext-envvars==0.0.2
 ckanext-googleanalyticsbasic==0.2.0


### PR DESCRIPTION
# Pull Request

Related to 
[Inventory data.json export error#4237](https://github.com/GSA/data.gov/issues/4237)
[mimetype 'Geotiff' missing from the ckan resource_formats #4252](https://github.com/GSA/data.gov/issues/4252)

## About

Added code to replace None with general mimetype to avoid concatenation type error
Added additional resource formats file to convert `geotiff` to` image/tiff`

