### PR TITLE
move inventory staging from sandbox to login.gov prod

### DIFF
--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,8 +1,8 @@
 app_name: inventory
 space_name: staging
 
-ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-stage-inventory
-ckanext__saml2auth__idp_metadata__local_path: config/login.sandbox.idp.xml
+ckanext__saml2auth__entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-staging-inventory
+ckanext__saml2auth__idp_metadata__local_path: config/login.production.idp.xml
 
 # Number of application instances to run in cloud.gov
 instances: 2


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4222

## About

login.gov updated their apps with latest certs. Now it is time to move staging-inventory from sandbox to login.gov prod. So that `development` ckan apps are talking to identity sandbox; `staging` and prod ckan apps are talking to login.gov prod.

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
