### PR TITLE
Add CSRF secret

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,7 @@ DB_CKAN_DB=ckan
 
 CKAN___BEAKER__SESSION__URL=postgresql://ckan:ckan@db/ckan
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME
+CKAN___WTF_CSRF_SECRET_KEY=CHANGE_ME
 # See https://docs.ckan.org/en/latest/maintaining/configuration.html#api-token-settings
 CKAN___API_TOKEN__JWT__ENCODE__SECRET=string:CHANGE_ME
 CKAN___API_TOKEN__JWT__DECODE__SECRET=string:CHANGE_ME

--- a/.profile
+++ b/.profile
@@ -52,7 +52,7 @@ export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${CONFIG_DIR}/saml2_certificate.pem
 # We need the secret credentials for various application components (DB configuration, license keys, etc)
 DS_RO_PASSWORD=$(vcap_get_service secrets .credentials.DS_RO_PASSWORD)
 export NEW_RELIC_LICENSE_KEY=$(vcap_get_service secrets .credentials.NEW_RELIC_LICENSE_KEY)
-export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION_SECRET)
+export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION__SECRET)
 export CKAN___WTF_CSRF_SECRET_KEY=$(vcap_get_service secrets .credentials.CKAN___WTF_CSRF_SECRET_KEY)
 export CKAN___CACHE_DIR=${SHARED_DIR}/cache
 

--- a/.profile
+++ b/.profile
@@ -53,6 +53,7 @@ export CKANEXT__SAML2AUTH__CERT_FILE_PATH=${CONFIG_DIR}/saml2_certificate.pem
 DS_RO_PASSWORD=$(vcap_get_service secrets .credentials.DS_RO_PASSWORD)
 export NEW_RELIC_LICENSE_KEY=$(vcap_get_service secrets .credentials.NEW_RELIC_LICENSE_KEY)
 export CKAN___BEAKER__SESSION__SECRET=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION_SECRET)
+export CKAN___WTF_CSRF_SECRET_KEY=$(vcap_get_service secrets .credentials.CKAN___WTF_CSRF_SECRET_KEY)
 export CKAN___CACHE_DIR=${SHARED_DIR}/cache
 
 # Get sysadmins list by a user-provided-service per environment
@@ -99,7 +100,6 @@ export CKAN_SOLR_URL=$CKAN_SOLR_BASE_URL/solr/$SOLR_COLLECTION
 # Edit the config file to validate debug is off and utilizes the correct port
 export CKAN_INI="${HOME}/config/ckan.ini"
 # ckan config-tool $CKAN_INI -s server:main -e port=${PORT}
-ckan config-tool $CKAN_INI "WTF_CSRF_SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe())')"
 ckan config-tool $CKAN_INI --section DEFAULT --edit debug=false
 
 echo "Setting up the datastore user"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Tips on managing
 When creating the service for the first time, use `create-user-provided-service`
 instead of update.
 
-    cf update-user-provided-service ${app_name}-secrets -p "CKAN___BEAKER__SESSION_SECRET, CKAN___WTF_CSRF_SECRET_KEY, DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY, SAML2_PRIVATE_KEY"
+    cf update-user-provided-service ${app_name}-secrets -p "CKAN___BEAKER__SESSION__SECRET, CKAN___WTF_CSRF_SECRET_KEY, DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY, SAML2_PRIVATE_KEY"
 
 Name | Description | Where to find
 ---- | ----------- | -------------

--- a/README.md
+++ b/README.md
@@ -129,11 +129,12 @@ Tips on managing
 When creating the service for the first time, use `create-user-provided-service`
 instead of update.
 
-    cf update-user-provided-service ${app_name}-secrets -p "CKAN___BEAKER__SESSION_SECRET, DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY, SAML2_PRIVATE_KEY"
+    cf update-user-provided-service ${app_name}-secrets -p "CKAN___BEAKER__SESSION_SECRET, CKAN___WTF_CSRF_SECRET_KEY, DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY, SAML2_PRIVATE_KEY"
 
 Name | Description | Where to find
 ---- | ----------- | -------------
 CKAN___BEAKER__SESSION__SECRET | Session secret for encrypting CKAN sessions.  | `pwgen -s 32 1`
+CKAN___WTF_CSRF_SECRET_KEY | CSRF secret for generating CSRF tokens.  | `pwgen -s 32 1`
 DS_RO_PASSWORD | Read-only password to configure for the [datastore](https://docs.ckan.org/en/2.9/maintaining/datastore.html) user. | Initially randomly generated [#2839](https://github.com/GSA/datagov-deploy/issues/2839)
 NEW_RELIC_LICENSE_KEY | New Relic License key. | New Relic account settings.
 SAML2_PRIVATE_KEY | Base64 encoded SAML2 key matching the certificate configured for Login.gov | [Google Drive](https://drive.google.com/drive/u/0/folders/1VguFPRiRb1Ljnm_6UShryHWDofX0xBnU).

--- a/config/ckan.ini
+++ b/config/ckan.ini
@@ -55,6 +55,9 @@ who.timeout = 900
 # who.httponly = True # DEFAULT True already
 who.secure = True
 
+# secret for generating CSRF secure tokens
+WTF_CSRF_SECRET_KEY = $CKAN___WTF_CSRF_SECRET_KEY
+
 ckan.csrf_protection.ignore_extensions=False
 
 ## Database Settings

--- a/start.sh
+++ b/start.sh
@@ -68,7 +68,6 @@ ckan db upgrade
 # Reference: https://github.com/okfn/docker-ckan/commit/4746d8cc9d1a6ecb0c209cdf501b8d0f4f3cd224
 echo "Setting beaker.session.secret in ini file"
 ckan config-tool $CKAN_INI "beaker.session.secret=$(python3 -c 'import secrets; print(secrets.token_urlsafe())')"
-ckan config-tool $CKAN_INI "WTF_CSRF_SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe())')"
 JWT_SECRET=$(python3 -c 'import secrets; print("string:" + secrets.token_urlsafe())')
 ckan config-tool $CKAN_INI "api_token.jwt.encode.secret=$JWT_SECRET"
 ckan config-tool $CKAN_INI "api_token.jwt.decode.secret=$JWT_SECRET"


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4381

## About

- Add `CKAN___WTF_CSRF_SECRET_KEY` to fix CSRF error when there are multiple instances
- fix `CKAN___BEAKER__SESSION_SECRET` naming. Should be `BEAKER__SESSION__SECRET`, two underscore at the end.

pre-deployment: update the user provided service to add the two keys added into inventory-secrets. 
post-deployment: update the user provided service to remove the wrong key from inventory-secrets. 

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [x] The actual code changes.
- [ ] Tests written and passed.
- [x] Any changes to docs?
- [x] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
