### PR TITLE
set ckanext.saml2auth.create_user_via_saml in ckan.ini

### DIFF
--- a/config/ckan.ini
+++ b/config/ckan.ini
@@ -192,6 +192,7 @@ ckanext.saml2auth.want_assertions_signed=false
 ckanext.saml2auth.want_assertions_or_response_signed=true
 ckanext.saml2auth.enable_ckan_internal_login=false
 ckanext.saml2auth.requested_authn_context = http://idmanagement.gov/ns/assurance/aal/3?hspd12=true
+ckanext.saml2auth.create_user_via_saml=false
 
 ## Feeds Settings
 


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4160
## About

Need to set saml2auth config in ckan.ini for cloud.gov apps.

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [x] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
