### PR TITLE
it hangs on local env with only 1 worker

### DIFF
--- a/config/server_start.sh
+++ b/config/server_start.sh
@@ -8,4 +8,4 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 # start xloader
 exec ckan jobs worker &
 # Fire it up!
-exec newrelic-admin run-program gunicorn "wsgi:application" --config "$DIR/gunicorn.conf.py" -b "0.0.0.0:$PORT" --chdir $DIR  --timeout 120 --forwarded-allow-ips='*'
+exec newrelic-admin run-program gunicorn "wsgi:application" --config "$DIR/gunicorn.conf.py" -b "0.0.0.0:$PORT" --chdir $DIR  --timeout 120 --workers 2 --forwarded-allow-ips='*'


### PR DESCRIPTION
change workers count from default 1 to 2. 
Noticed on local, clicking on a link often hangs. more workers fixes it.