### PR TITLE
setup -> setup_method

### DIFF
--- a/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
+++ b/ckanext/datagov_inventory/tests/logic/auth/test_auth.py
@@ -27,7 +27,7 @@ is_denied = False
 @pytest.mark.usefixtures("with_request_context")
 class TestDatagovInventoryAuth(FunctionalTestBase):
 
-    def setup(self):
+    def setup_method(self):
         super(TestDatagovInventoryAuth, self).setup_class()
         # Start with a clean database and index for each test
         self.clean_datastore()


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/4606

## About

nose-specific method: `setup(self)` is deprecated. change it to: `setup_method(self)`

