### PR TITLE
extended the snyk exception date

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -28,7 +28,7 @@ ignore:
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
-        expires: 2024-06-01T16:20:58.017Z
+        expires: 2024-09-30T16:20:58.017Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-FLASK-5490129:
     - '*':
@@ -66,19 +66,19 @@ ignore:
     - '*':
         reason: >-
            Not affecting us since no debugger is enabled in cloud.gov apps
-        expires: 2024-06-31T16:20:58.017Z
+        expires: 2024-09-30T16:20:58.017Z
   SNYK-PYTHON-CRYPTOGRAPHY-7161587:
     - '*':
         reason: >-
            No remediation available yet. Issue tracked in github:
            https://github.com/GSA/data.gov/issues/4781
-        expires: 2024-06-31T16:20:58.017Z
+        expires: 2024-09-30T16:20:58.017Z
   SNYK-PYTHON-PYOPENSSL-7161590:
     - '*':
         reason: >-
            No remediation available yet. Issue tracked in github:
            https://github.com/GSA/data.gov/issues/4782
-        expires: 2024-06-31T16:20:58.017Z
+        expires: 2024-09-30T16:20:58.017Z
 patch: {}
 # specify the directories or files to be excludeed from import:
 exclude:


### PR DESCRIPTION

extended the date for snyk exceptions which not be accepted in CKAN 2.10 yet. 

Related to https://github.com/GSA/data.gov/issues/4803


