### PR TITLE
snyk test in PR

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,6 +2,9 @@
 name: Check for Snyk Vulnerabilities
 
 on:   # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'  # every day at 12pm UTC
@@ -58,7 +61,7 @@ jobs:
           # Fail so that PR is created
           exit 1
       - name: Create Pull Request
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'schedule' }}
         id: scpr
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
The integrated security/snyk check in PR is not reliable. We can do it using `snyk test` command.