### PR TITLE
ckan 2.10.5

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,96 +7,60 @@ ignore:
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
-        expires: 2024-08-31T13:35:17.967Z
+        expires: 2024-11-30T13:35:17.967Z
         created: 2023-11-01T13:35:17.972Z
   SNYK-PYTHON-BEAKER-575115:
     - '*':
         reason: >-
           No remediation available yet; Not affecting us since the storage is
           not accessible to any other client
-        expires: 2024-08-31T16:20:58.017Z
+        expires: 2024-11-30T16:20:58.017Z
         created: 2022-12-08T16:20:58.023Z
   SNYK-PYTHON-WERKZEUG-3319936:
     - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
-        expires: 2024-08-31T16:20:58.017Z
+        expires: 2024-11-30T16:20:58.017Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-WERKZEUG-3319935:
     - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4217
-        expires: 2024-09-30T16:20:58.017Z
+        expires: 2024-11-30T16:20:58.017Z
         created: 2023-02-15T16:20:58.023Z
   SNYK-PYTHON-FLASK-5490129:
     - '*':
         reason: >-
           Upgrade path is complex, Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4303
-        expires: 2024-08-31T16:20:58.017Z
+        expires: 2024-11-30T16:20:58.017Z
         created: 2023-05-08T16:20:58.023Z
   SNYK-PYTHON-PYOPENSSL-6149520:
     - '*':
         reason: >-
           No remediation available yet; Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4532
-        expires: 2024-08-31T19:29:54.032Z
+        expires: 2024-11-30T19:29:54.032Z
         created: 2024-01-11T19:29:54.039Z
   SNYK-PYTHON-PYOPENSSL-6157250:
     - '*':
         reason: >-
           No remediation available yet; Issue tracked in github:
           https://github.com/GSA/data.gov/issues/4591
-        expires: 2024-10-31T19:29:54.032Z
-  SNYK-PYTHON-CRYPTOGRAPHY-6592767:
-    - '*':
-        reason: >-
-          No remediation available yet; Low severity.
-        expires: 2024-10-24T17:21:30.083Z
-        created: 2024-04-24T17:21:30.089Z
+        expires: 2024-11-30T19:29:54.032Z
   SNYK-PYTHON-PYOPENSSL-6592766:
     - '*':
         reason: >-
           No remediation available yet; Low severity.
-        expires: 2024-10-24T17:24:47.251Z
+        expires: 2024-11-30T17:24:47.251Z
         created: 2024-04-24T17:24:47.257Z
   SNYK-PYTHON-WERKZEUG-6808933:
     - '*':
         reason: >-
            Not affecting us since no debugger is enabled in cloud.gov apps
-        expires: 2024-09-30T16:20:58.017Z
-  SNYK-PYTHON-CRYPTOGRAPHY-7161587:
-    - '*':
-        reason: >-
-           No remediation available yet. Issue tracked in github:
-           https://github.com/GSA/data.gov/issues/4781
-        expires: 2024-09-30T16:20:58.017Z
-  SNYK-PYTHON-PYOPENSSL-7161590:
-    - '*':
-        reason: >-
-           No remediation available yet. Issue tracked in github:
-           https://github.com/GSA/data.gov/issues/4782
-        expires: 2024-09-30T16:20:58.017Z
-  SNYK-PYTHON-CKAN-7786366:
-    - '*':
-        reason: >-
-           Remediation in progress. Issue tracked in github:
-           https://github.com/GSA/data.gov/issues/4854
-        expires: 2024-09-30T16:20:58.017Z
-  SNYK-PYTHON-CKAN-7786367:
-    - '*':
-        reason: >-
-           Remediation in progress. Issue tracked in github:
-           https://github.com/GSA/data.gov/issues/4854
-        expires: 2024-09-30T16:20:58.017Z
-  SNYK-PYTHON-CKAN-7786369:
-    - '*':
-        reason: >-
-           Remediation in progress. Issue tracked in github:
-           https://github.com/GSA/data.gov/issues/4854
-        expires: 2024-09-30T16:20:58.017Z
+        expires: 2024-11-30T16:20:58.017Z
 patch: {}
 # specify the directories or files to be excludeed from import:
 exclude:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-dev:2.10.4
+FROM ckan/ckan-dev:2.10.5
 # Inherit from here: https://github.com/okfn/docker-ckan/blob/master/ckan-dev/2.10/Dockerfile
 # And then from here: https://github.com/okfn/docker-ckan/blob/master/ckan-base/2.10/Dockerfile
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ckan:
-    image: datagov/inventory-app:2.10.4
+    image: datagov/inventory-app:2.10.5
     build: .
     command: /app/start.sh
     depends_on:

--- a/e2e/cypress/integration/ckan_extensions.spec.js
+++ b/e2e/cypress/integration/ckan_extensions.spec.js
@@ -2,7 +2,7 @@ describe('CKAN Extensions', () => {
     it('Uses CKAN 2.10', () => {
         cy.request('/api/action/status_show').should((response) => {
             expect(response.body).to.have.property('success', true);
-            expect(response.body.result).to.have.property('ckan_version', '2.10.4');
+            expect(response.body.result).to.have.property('ckan_version', '2.10.5');
         });
     });
 

--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -1,4 +1,4 @@
-git+https://github.com/GSA/ckan.git@ckan-2-10-4-fork#egg=ckan
+git+https://github.com/GSA/ckan.git@ckan-2-10-5-fork#egg=ckan
 # TODO https://github.com/GSA/datagov-deploy/issues/2794
 git+https://github.com/GSA/ckanext-saml2auth.git@datagov#egg=ckanext-saml2auth
 git+https://github.com/keitaroinc/ckanext-s3filestore.git#egg=ckanext-s3filestore
@@ -34,18 +34,20 @@ Flask-WTF==1.0.1
 flask-multistatic==1.0
 greenlet==2.0.2
 # Jinja2==3.1.2
-PyJWT==2.4.0
 Markdown==3.4.1
+packaging==24.1
 passlib==1.7.4
 polib==1.1.1
 psycopg2==2.9.3
+PyJWT==2.4.0
+pyparsing==3.1.2
 python-magic==0.4.27
 pysolr==3.9.0
 python-dateutil==2.8.2
 pytz
 PyUtilib==6.0.0
 pyyaml==6.0.1
-requests~=2.32.2
+requests~=2.32.3
 rq==1.11.0
 simplejson==3.18.0
 SQLAlchemy[mypy]==1.4.41

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 alembic==1.8.1
 async-timeout==4.0.3
-attrs==24.1.0
+attrs==24.2.0
 Babel==2.10.3
 Beaker==1.11.0
 bleach==5.0.1
 blinker==1.5
-boto3==1.34.153
-botocore==1.34.153
-certifi==2024.7.4
-cffi==1.16.0
+boto3==1.35.10
+botocore==1.35.10
+certifi==2024.8.30
+cffi==1.17.0
 chardet==5.2.0
 charset-normalizer==3.3.2
-ckan @ git+https://github.com/GSA/ckan.git@7159a872ba740069b768fcd2a43cde81a57ee492
+ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca194
 ckanext-datajson==0.1.25
 ckanext-dcat-usmetadata==0.6.0
 ckanext-envvars==0.0.3
@@ -35,9 +35,9 @@ flask-multistatic==1.0
 Flask-WTF==1.0.1
 gevent==24.2.1
 greenlet==2.0.2
-gunicorn==22.0.0
+gunicorn==23.0.0
 html5lib==1.1
-idna==3.7
+idna==3.8
 ijson==3.3.0
 importlib-resources==5.13.0
 itsdangerous==2.0.1
@@ -54,7 +54,7 @@ MarkupSafe==2.0.1
 messytables==0.15.2
 mypy==1.10.1
 mypy-extensions==1.0.0
-newrelic==9.12.0
+newrelic==9.13.0
 nose==1.3.7
 openpyxl==3.1.5
 packaging==24.1
@@ -95,7 +95,7 @@ tzlocal==4.2
 unicodecsv==0.14.1
 Unidecode==1.0.22
 urllib3==2.2.2
-watchdog==4.0.1
+watchdog==5.0.1
 webassets==2.0
 webencodings==0.5.1
 Werkzeug==2.0.3


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4855

## About

Upgrade ckan to core 2.10.5 and relevant requirements

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [x] The actual code changes.
- [x] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
