### PR TITLE
Adding USDA OCIO as a publisher

### DIFF
--- a/config/data/inventory_publishers.csv
+++ b/config/data/inventory_publishers.csv
@@ -15,6 +15,7 @@ department-of-agriculture,Department of Agriculture,GIPSA,Federal Grain Inspecti
 department-of-agriculture,Department of Agriculture,National Institute of Food and Agriculture,,,,
 department-of-agriculture,Department of Agriculture,National Agricultural Statistics Service,,,,
 department-of-agriculture,Department of Agriculture,Natural Resources Conservation Service,Colorado State University,,,
+department-of-agriculture,Department of Agriculture,Office of the Chief Information Officer,,,,
 department-of-agriculture,Department of Agriculture,Rural Development,,,,
 department-of-agriculture,Department of Agriculture,US Forest Service,,,,
 department-of-commerce,Department of Commerce,Bureau of Industry and Security,,,,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 alembic==1.8.1
-async-timeout==5.0.0
-attrs==24.2.0
+async-timeout==5.0.1
+attrs==24.3.0
 Babel==2.10.3
 Beaker==1.11.0
 bleach==5.0.1
 blinker==1.5
-boto3==1.35.53
-botocore==1.35.53
-certifi==2024.8.30
+boto3==1.35.90
+botocore==1.35.90
+certifi==2024.12.14
 cffi==1.17.1
 chardet==5.2.0
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
 ckan @ git+https://github.com/GSA/ckan.git@8c4a517efeac80db098cc6ba144cb742bbeca194
 ckanext-datajson==0.1.27
 ckanext-dcat-usmetadata==0.6.0
@@ -19,13 +19,13 @@ ckanext-googleanalyticsbasic==0.2.1
 ckanext-s3filestore @ git+https://github.com/keitaroinc/ckanext-s3filestore.git@caf88c0352ffe7b4432d3d55ddfb0a71249ceddd
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@387cfc1c6a7619f670bf387384f2634516de5844
 ckanext-usmetadata==0.3.2
--e git+https://github.com/ckan/ckanext-xloader.git@6b6895990a7b3497b274afe4e83e3db794d9dd69#egg=ckanext_xloader
+-e git+https://github.com/ckan/ckanext-xloader.git@dbc7a3c870a0a7c1c115dcfdde0c4a2a89867565#egg=ckanext_xloader
 ckantoolkit==0.0.7
 click==8.1.3
-cryptography==43.0.3
+cryptography==44.0.0
 defusedxml==0.7.1
 dominate==2.7.0
-elementpath==4.6.0
+elementpath==4.7.0
 et_xmlfile==2.0.0
 feedgen==0.9.0
 Flask==2.0.3
@@ -33,7 +33,7 @@ Flask-Babel==1.0.0
 Flask-Login==0.6.1
 flask-multistatic==1.0
 Flask-WTF==1.0.1
-gevent==24.10.3
+gevent==24.11.1
 greenlet==3.1.1
 gunicorn==23.0.0
 html5lib==1.1
@@ -48,13 +48,13 @@ jsonlines==4.0.0
 jsonschema==2.4.0
 linear-tsv==1.1.0
 lxml==4.9.1
-Mako==1.3.6
+Mako==1.3.8
 Markdown==3.4.1
 MarkupSafe==2.0.1
 messytables==0.15.2
 mypy==1.10.1
 mypy-extensions==1.0.0
-newrelic==10.2.0
+newrelic==10.4.0
 nose==1.3.7
 openpyxl==3.1.5
 packaging==24.1
@@ -65,7 +65,7 @@ polib==1.1.1
 psycopg2==2.9.3
 pycparser==2.22
 PyJWT==2.4.0
-pyOpenSSL==24.2.1
+pyOpenSSL==24.3.0
 pyparsing==3.1.2
 pysaml2==7.3.1
 pysolr==3.9.0
@@ -75,26 +75,26 @@ pytz==2024.2
 pytz-deprecation-shim==0.1.0.post0
 PyUtilib==6.0.0
 PyYAML==6.0.1
-redis==5.2.0
+redis==5.2.1
 requests==2.32.3
 rfc3987==1.3.8
 rq==1.11.0
-s3transfer==0.10.3
+s3transfer==0.10.4
 sansjson==0.3.0
 setuptools==71.0.4
 simplejson==3.18.0
-six==1.16.0
+six==1.17.0
 SQLAlchemy==1.4.41
 sqlalchemy2-stubs==0.0.2a38
 sqlparse==0.5.0
 tabulator==1.53.5
-tomli==2.0.2
+tomli==2.2.1
 typing_extensions==4.3.0
 tzdata==2024.2
 tzlocal==4.2
 unicodecsv==0.14.1
 Unidecode==1.0.22
-urllib3==2.2.3
+urllib3==2.3.0
 watchdog==6.0.0
 webassets==2.0
 webencodings==0.5.1


### PR DESCRIPTION
# Pull Request

Related to email request from USDA

## About

"I’m adding a dataset to [inventory.data.gov](http://inventory.data.gov/) and I can’t find the right Publisher.  I was looking for something like Office of the Chief Information Officer, or just make the Publisher the same as the Organization, but those don’t seem to be options.  Can a new Publisher be created?"

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
