### PR TITLE
keep session live for active user

### DIFF
--- a/.env
+++ b/.env
@@ -20,8 +20,11 @@ DB_CKAN_PASSWORD=pass
 DB_CKAN_DB=ckan
 
 CKAN___SECRET_KEY=CHANGE_ME
-CKAN___BEAKER__SESSION__URL=postgresql://ckan:ckan@db/ckan
-CKAN___BEAKER__SESSION__SECRET=CHANGE_ME
+
+# uncomment to have session behave same as apps on cloud.gov
+# CKAN___SESSION_PERMANENT=False
+# CKAN___PERMANENT_SESSION_LIFETIME=900
+
 CKAN___WTF_CSRF_SECRET_KEY=CHANGE_ME
 # See https://docs.ckan.org/en/latest/maintaining/configuration.html#api-token-settings
 CKAN___API_TOKEN__JWT__ENCODE__SECRET=string:CHANGE_ME

--- a/ckanext/datagov_inventory/plugin.py
+++ b/ckanext/datagov_inventory/plugin.py
@@ -9,7 +9,7 @@ from ckan.logic.auth.get import package_show
 from ckan.plugins.toolkit import config
 import ckan.authz as authz
 
-from flask import Blueprint, redirect
+from flask import Blueprint, redirect, session
 import logging
 import re
 
@@ -131,3 +131,9 @@ def check_dataset_access():
     if toolkit.request.path in ('/dataset/', '/dataset'):
         if not current_user.is_authenticated and not g.user:
             return base.render(u'error/anonymous.html'), 403
+
+
+@pusher.before_app_request
+def refresh_session():
+    """ Refresh session expiration time on each request """
+    session.modified = True

--- a/config/ckan.ini
+++ b/config/ckan.ini
@@ -30,19 +30,9 @@ ckanext.datajson.inventory_links_enabled = True
 ckanext.datajson.export_map_filename = export.inventory.map.sample.json
 ckanext.datajson.url_enabled = False
 
-# This is the secret token that the beaker library uses to hash the cookie sent
-# to the client. `ckan make-config` generates a unique value for this each
-# time it generates a config file.
-beaker.session.secret = $CKAN___BEAKER__SESSION__SECRET
-
-beaker.session.type=ext:database
-beaker.session.cookie_expires=true
-beaker.session.secure = True
-beaker.session.samesite = Lax
-#beaker.session.url = $CKAN___BEAKER__SESSION__URL
 # 900 seconds = 15 mins
-beaker.session.timeout=900
-beaker.session.lock_dir=/var/tmp/ckan/lock
+SESSION_PERMANENT=False
+PERMANENT_SESSION_LIFETIME=900
 
 # `paster make-config` generates a unique value for this each time it generates
 # a config file.


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/5079#issuecomment-2648831450

## About
Expected session behavior:
- Session should not end for active user
- Session ends when user idles for 15 mins
- Session ends when browser is close

After CKAN 2.11, the sessions handling has been refactored, dropping the Beaker library in favour of [Flask-Session](https://flask-session.readthedocs.io/en/latest/config.html).

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
