### PR TITLE
make requirements

### DIFF
--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -84,7 +84,7 @@ pyparsing # need to avoid solr missing module error on cloud.gov
 urllib3>=1.26.19
 
 certifi>=2024.7.4
-setuptools~=71.0.3
+setuptools>=80.3.1
 
 # Pin MarkupSafe to avoid button issue data.gov/issues/4954 for logged in user
 # https://github.com/GSA/data.gov/issues/4954

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ rfc3987==1.3.8
 rq==1.16.2
 s3transfer==0.12.0
 sansjson==0.3.0
-setuptools==71.0.4
+setuptools==80.3.1
 simplejson==3.19.2
 six==1.17.0
 SQLAlchemy==1.4.52

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,16 @@ attrs==25.3.0
 Babel==2.15.0
 bleach==6.1.0
 blinker==1.8.2
-boto3==1.37.25
-botocore==1.37.25
+boto3==1.38.8
+botocore==1.38.8
 cachelib==0.13.0
-certifi==2025.1.31
+certifi==2025.4.26
 cffi==1.17.1
 chardet==5.2.0
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
 ckan @ git+https://github.com/ckan/ckan.git@5bd556eb4370614e0f87dea5aebea7abee42d0a6
 ckanext-datajson==0.1.28
-ckanext-dcat-usmetadata==0.6.1
+ckanext-dcat-usmetadata==0.6.2
 ckanext-envvars==0.0.6
 ckanext-s3filestore @ git+https://github.com/keitaroinc/ckanext-s3filestore.git@caf88c0352ffe7b4432d3d55ddfb0a71249ceddd
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@99f35585c219a5cd39717b8c42cc54cdd959dfb4
@@ -21,10 +21,10 @@ ckanext-usmetadata==0.3.3
 -e git+https://github.com/ckan/ckanext-xloader.git@11eb3e64867ac9aa3cab95236e3eed520f601012#egg=ckanext_xloader
 ckantoolkit==0.0.7
 click==8.1.8
-cryptography==44.0.2
+cryptography==44.0.3
 defusedxml==0.7.1
 dominate==2.9.1
-elementpath==4.8.0
+elementpath==5.0.0
 et_xmlfile==2.0.0
 feedgen==1.0.0
 Flask==3.0.3
@@ -32,8 +32,8 @@ flask-babel==4.0.0
 Flask-Login==0.6.3
 Flask-Session==0.8.0
 Flask-WTF==1.2.1
-gevent==24.11.1
-greenlet==3.1.1
+gevent==25.4.2
+greenlet==3.2.1
 gunicorn==23.0.0
 html5lib==1.1
 idna==3.10
@@ -47,19 +47,19 @@ jsonlines==4.0.0
 jsonschema==2.4.0
 linear-tsv==1.1.0
 lxml==4.9.1
-Mako==1.3.9
+Mako==1.3.10
 Markdown==3.6
 MarkupSafe==2.1.5
 messytables==0.15.2
 msgspec==0.18.6
 mypy==1.15.0
-mypy-extensions==1.0.0
-newrelic==10.8.1
+mypy_extensions==1.1.0
+newrelic==10.11.0
 openpyxl==3.1.5
 packaging==24.1
 passlib==1.7.4
 pika==1.3.2
-pip==25.1
+pip==25.0.1
 polib==1.2.0
 psycopg2==2.9.9
 pycparser==2.22
@@ -72,11 +72,11 @@ python-dateutil==2.9.0.post0
 python-magic==0.4.27
 pytz==2025.2
 PyYAML==6.0.1
-redis==5.2.1
+redis==6.0.0
 requests==2.32.3
 rfc3987==1.3.8
 rq==1.16.2
-s3transfer==0.11.4
+s3transfer==0.12.0
 sansjson==0.3.0
 setuptools==71.0.4
 simplejson==3.19.2
@@ -90,7 +90,7 @@ typing_extensions==4.12.2
 tzlocal==5.2
 unicodecsv==0.14.1
 Unidecode==1.0.22
-urllib3==2.3.0
+urllib3==2.4.0
 watchdog==6.0.0
 webassets==2.0
 webencodings==0.5.1
@@ -98,6 +98,6 @@ Werkzeug==3.0.6
 wheel==0.42.0
 WTForms==3.2.1
 xlrd==2.0.1
-xmlschema==3.4.5
+xmlschema==4.0.1
 zope.event==5.0
 zope.interface==6.4.post2


### PR DESCRIPTION
Run `make requirements`, fix [snyk exceptions](https://github.com/GSA/inventory-app/actions/runs/14835934951/job/41647102282). 

```
Issues to fix by upgrading dependencies:

  Upgrade gevent@24.11.1 to gevent@25.4.1 to fix
  ✗ HTTP Request Smuggling (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-GEVENT-9919772] in gevent@24.11.1
    introduced by gevent@24.11.1

  Upgrade setuptools@71.0.4 to setuptools@78.1.1 to fix
  ✗ Directory Traversal (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-996[46](https://github.com/GSA/inventory-app/actions/runs/14835934951/job/41647102282#step:6:47)06] in setuptools@71.0.4
    introduced by setuptools@71.0.4 and 5 other path(s)
```