### PR TITLE
snyk exception setutools

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,12 +2,12 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-PYTHON-CKAN-8689473:
+  SNYK-PYTHON-SETUPTOOLS-9964606:
     - '*':
         reason: >-
            Issue created and triaged. GitHub issue:
-           https://github.com/GSA/data.gov/issues/5071
-        expires: 2025-03-31T16:20:58.017Z
+           https://github.com/GSA/data.gov/issues/5228
+        expires: 2025-06-03T16:20:58.017Z
 patch: {}
 # specify the directories or files to be excludeed from import:
 exclude:

--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -84,7 +84,7 @@ pyparsing # need to avoid solr missing module error on cloud.gov
 urllib3>=1.26.19
 
 certifi>=2024.7.4
-setuptools>=80.3.1
+setuptools~=71.0.3
 
 # Pin MarkupSafe to avoid button issue data.gov/issues/4954 for logged in user
 # https://github.com/GSA/data.gov/issues/4954

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ rfc3987==1.3.8
 rq==1.16.2
 s3transfer==0.12.0
 sansjson==0.3.0
-setuptools==80.3.1
+setuptools==71.0.4
 simplejson==3.19.2
 six==1.17.0
 SQLAlchemy==1.4.52


### PR DESCRIPTION
# Pull Request

Related to 
- https://github.com/GSA/data.gov/issues/5228

## About

setuptools stays pinned at 71.0.4.

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
