### PR TITLE
update werkzeug

### DIFF
--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -48,7 +48,7 @@ sqlparse==0.5.4
 typing_extensions==4.12.2
 tzlocal==5.2
 webassets==2.0
-Werkzeug[watchdog]==3.1.4
+Werkzeug[watchdog]==3.1.5
 zope.interface==6.4post2
 
 # # ckanext-saml2 dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ attrs==25.4.0
 Babel==2.15.0
 bleach==6.1.0
 blinker==1.8.2
-boto3==1.42.15
-botocore==1.42.15
+boto3==1.42.32
+botocore==1.42.32
 cachelib==0.13.0
-certifi==2025.11.12
+certifi==2026.1.4
 cffi==2.0.0
 chardet==5.2.0
 charset-normalizer==3.4.4
@@ -24,7 +24,7 @@ click==8.3.1
 cryptography==45.0.7
 defusedxml==0.7.1
 dominate==2.9.1
-elementpath==5.0.4
+elementpath==5.1.1
 et_xmlfile==2.0.0
 feedgen @ git+https://github.com/GSA/python-feedgen.git@b1fe34a7e14ebdaf6f415cdee5855c3c77305f16
 Flask==3.0.3
@@ -41,11 +41,11 @@ ijson==3.4.0.post0
 importlib-resources==5.13.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
-jmespath==1.0.1
+jmespath==1.1.0
 json-table-schema==0.2.1
 jsonlines==4.0.0
 jsonschema==2.4.0
-librt==0.7.4
+librt==0.7.8
 linear-tsv==1.1.0
 lxml==4.9.1
 Mako==1.3.10
@@ -59,12 +59,12 @@ newrelic==11.2.0
 openpyxl==3.1.5
 packaging==24.1
 passlib==1.7.4
-pathspec==0.12.1
+pathspec==1.0.3
 pika==1.3.2
 pip==25.3
 polib==1.2.0
 psycopg2==2.9.9
-pycparser==2.23
+pycparser==3.0
 PyJWT==2.8.0
 pyOpenSSL==25.3.0
 pyparsing==3.1.2
@@ -87,7 +87,7 @@ SQLAlchemy==1.4.52
 sqlalchemy2-stubs==0.0.2a38
 sqlparse==0.5.4
 tabulator==1.53.5
-tomli==2.3.0
+tomli==2.4.0
 typing_extensions==4.12.2
 tzlocal==5.2
 unicodecsv==0.14.1
@@ -100,6 +100,6 @@ Werkzeug==3.1.5
 wheel==0.42.0
 WTForms==3.2.1
 xlrd==2.0.2
-xmlschema==4.2.0
+xmlschema==4.3.1
 zope.event==6.1
 zope.interface==6.4.post2


### PR DESCRIPTION
werkzeug is already on 3.1.5 in requirements.txt but not in requirements.in.txt, snyk dashboard complains about its version

- pin werkzeug to 3.1.5 in requirements.in.txt
- run `make requirements`