### PR TITLE
update packages

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,19 +4,11 @@ language-settings:
   python: "3.10"
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-PYTHON-CKAN-13774796:
+  SNYK-PYTHON-CKAN-16322869:
     - '*':
         reason: >-
-          postponing in favor of new catalog development/release
-        expires: 2026-01-29T05:30:00.000Z
-        created: 2025-11-10T12:15:00.000Z
-
-  SNYK-PYTHON-CKAN-13774801:
-    - '*':
-        reason: >-
-          postponing in favor of new catalog development/release
-        expires: 2026-01-29T05:30:00.000Z
-        created: 2025-11-10T12:15:00.000Z
+          Ticket created https://github.com/GSA/data.gov/issues/5941
+        expires: 2026-06-04T05:30:00.000Z
 patch: {}
 # specify the directories or files to be excludeed from import:
 exclude:

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ jsonschema==2.4.0
 librt==0.9.0
 linear-tsv==1.1.0
 lxml==4.9.1
-Mako==1.3.10
+Mako==1.3.11
 Markdown==3.8.1
 MarkupSafe==2.1.5
 messytables==0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@062f26b19a5
 ckanext-usmetadata==0.3.3
 -e git+https://github.com/ckan/ckanext-xloader.git@11eb3e64867ac9aa3cab95236e3eed520f601012#egg=ckanext_xloader
 ckantoolkit==0.0.7
-click==8.3.2
+click==8.3.3
 cryptography==46.0.7
 defusedxml==0.7.1
 dominate==2.9.1


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/5944


  Upgrade mako@1.3.10 to mako@1.3.11 to fix
  ✗ Directory Traversal (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-MAKO-16098253] in mako@1.3.10
    introduced by mako@1.3.10 and 1 other path(s)

  Upgrade click@8.3.2 to click@8.3.3 to fix
  ✗ Command Injection (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CLICK-16347201] in click@8.3.2
    introduced by click@8.3.2 and 7 other path(s)
    
    