### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -5,6 +5,9 @@ on:   # yamllint disable-line rule:truthy
   issues:
     types: [opened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -4,6 +4,9 @@ name: commit
 on:
   push:
 
+permissions:
+  contents: read
+
 
 jobs:
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   create-cloudgov-services-staging:
     name: create services (staging)

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -6,6 +6,9 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '7/15 * * * *'  # every 15 mins
 
+permissions:
+  contents: read
+
 jobs:
   restart-staging:
     name: restart (staging)

--- a/.github/workflows/update_publishers.yml
+++ b/.github/workflows/update_publishers.yml
@@ -8,6 +8,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   update-publishers-staging:
     name: Update Publishers (Staging)


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to workflows missing token scopes:
  - `.github/workflows/add_to_project.yml`
  - `.github/workflows/commit.yml`
  - `.github/workflows/publish.yml`
  - `.github/workflows/restart.yml`
  - `.github/workflows/update_publishers.yml`
- Set `contents: read` as the minimal scope for these workflows.

## Why
The workflows currently rely on implicit token defaults. Explicit least-privilege scopes reduce unnecessary token access and satisfy workflow-permissions guidance.