### PR TITLE
Remove solr from local

### DIFF
--- a/.env
+++ b/.env
@@ -52,11 +52,7 @@ CKAN_DATASTORE_WRITE_URL=postgresql://datastore:pass@datastore/datastore
 CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:pass@datastore/datastore
 
 ## Search Settings
-CKAN_SITE_ID=inventory
-CKAN_SOLR_URL=http://solr:8983/solr/ckan
-CKAN_SOLR_BASE_URL=http://solr:8983
-CKAN_SOLR_USER=catalog
-CKAN_SOLR_PASSWORD='Bleeding-Edge'
+CKAN_SOLR_URL=http://placeholder-value.local
 
 ## Redis settings
 CKAN_REDIS_URL=redis://redis:6379/0

--- a/.snyk
+++ b/.snyk
@@ -8,22 +8,22 @@ ignore:
     - '*':
         reason: >-
           Ticket created https://github.com/GSA/data.gov/issues/5941
-        expires: 2026-06-04T05:30:00.000Z
+        expires: 2026-06-10T05:30:00.000Z
   SNYK-PYTHON-CKAN-16322864:
     - '*':
         reason: >-
           Ticket created https://github.com/GSA/data.gov/issues/5941
-        expires: 2026-06-04T05:30:00.000Z
+        expires: 2026-06-10T05:30:00.000Z
   SNYK-PYTHON-CKAN-16322872:
     - '*':
         reason: >-
           Ticket created https://github.com/GSA/data.gov/issues/5941
-        expires: 2026-06-04T05:30:00.000Z
+        expires: 2026-06-10T05:30:00.000Z
   SNYK-PYTHON-CKAN-16427188:
     - '*':
         reason: >-
           Ticket created https://github.com/GSA/data.gov/issues/5941
-        expires: 2026-06-04T05:30:00.000Z
+        expires: 2026-06-10T05:30:00.000Z
   SNYK-PYTHON-PIP-16964647:
     - '*':
         reason: >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     depends_on:
       - datastore
       - db
-      - solr
       - redis
       - localstack-container
     ports:
@@ -37,17 +36,6 @@ services:
       DB_CKAN_PASSWORD: pass
       DB_CKAN_DB: ckan
 
-  solr:
-    image: ghcr.io/gsa/catalog.data.gov.solr:8-stunnel-root
-    command: /app/solr/local_setup.sh
-    ports:
-      - "8983:8983"
-    deploy:
-      replicas: 1
-    volumes:
-      - solr_data:/var/solr
-      - .:/app
-
   redis:
     image: redis:alpine
 
@@ -70,4 +58,3 @@ services:
       - "./tmp/localstack:/var/lib/localstack"
 volumes:
   ckan:
-  solr_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ ckan @ git+https://github.com/GSA/ckan.git@1af1607e4f74fe4855b4ae4814c60fff1b2d1
 ckanext-datajson==0.1.28
 ckanext-dcat-usmetadata==0.6.3
 ckanext-envvars==0.0.6
-ckanext-pgsearch @ git+https://github.com/GSA/ckanext-pgsearch.git@2d5fe7023cc9caf7192da67e648b7fd9e484ca87
+ckanext-pgsearch @ git+https://github.com/GSA/ckanext-pgsearch.git@2f0b225bee1bdb457dffa9f857cd6e90a504547b
 ckanext-s3filestore @ git+https://github.com/keitaroinc/ckanext-s3filestore.git@e972ae3c36489dcfc716f75063ac64c13cde1146
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@062f26b19a525139bd613ef3654ca9dc64e0a096
 ckanext-usmetadata==0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ ckan @ git+https://github.com/GSA/ckan.git@1af1607e4f74fe4855b4ae4814c60fff1b2d1
 ckanext-datajson==0.1.28
 ckanext-dcat-usmetadata==0.6.3
 ckanext-envvars==0.0.6
-ckanext-pgsearch @ git+https://github.com/GSA/ckanext-pgsearch.git@2f0b225bee1bdb457dffa9f857cd6e90a504547b
+ckanext-pgsearch @ git+https://github.com/GSA/ckanext-pgsearch.git@48492c63fbaed8bcd892194b22192ffb404f2902
 ckanext-s3filestore @ git+https://github.com/keitaroinc/ckanext-s3filestore.git@e972ae3c36489dcfc716f75063ac64c13cde1146
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@062f26b19a525139bd613ef3654ca9dc64e0a096
 ckanext-usmetadata==0.3.3

--- a/start.sh
+++ b/start.sh
@@ -5,15 +5,12 @@ set -e
 function wait_for () {
     local host=$1
     local port=$2
-    
+
     while ! nc -z -w 5 "$host" "$port"; do
         sleep 1
     done
 }
 
-echo -n "Waiting for Solr..."
-wait_for solr 8983
-echo "ok"
 echo -n "Waiting for DB..."
 wait_for db 5432
 echo "ok"


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5887
## About

this should have gone with the previous [nosolr PR](https://github.com/GSA/inventory-app/pull/917). 
- remove solr from docker so that the tests are run without solr. 
- update pgsearch to handle datastore write error.

*Please review the pgsearch PR first
- https://github.com/GSA/ckanext-pgsearch/pull/3