### PR TITLE
bump requirements to use latest datajson plugin

### DIFF
--- a/requirements.in.txt
+++ b/requirements.in.txt
@@ -6,7 +6,7 @@ git+https://github.com/keitaroinc/ckanext-s3filestore.git#egg=ckanext-s3filestor
 -e git+https://github.com/ckan/ckanext-xloader.git@1.2.0#egg=ckanext-xloader
 
 ckanext-usmetadata>=0.3.3
-ckanext-datajson>=0.1.19
+ckanext-datajson>=0.1.29
 ckanext-dcat-usmetadata~=0.6.0
 ckanext-envvars>=0.0.3
 newrelic

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cffi==2.0.0
 chardet==7.4.3
 charset-normalizer==3.4.7
 ckan @ git+https://github.com/GSA/ckan.git@1af1607e4f74fe4855b4ae4814c60fff1b2d199c
-ckanext-datajson==0.1.28
+ckanext-datajson==0.1.29
 ckanext-dcat-usmetadata==0.6.3
 ckanext-envvars==0.0.6
 ckanext-pgsearch @ git+https://github.com/GSA/ckanext-pgsearch.git@2d5fe7023cc9caf7192da67e648b7fd9e484ca87


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5434
- https://github.com/GSA/ckanext-datajson/pull/164

## About

There was an issue in the datajson plugin for these exported zip files, this just updates to use that latest version which has been published.