### PR TITLE
Bump version to 0.3.4 for us metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ckanext-usmetadata==0.3.4
 -e git+https://github.com/ckan/ckanext-xloader.git@11eb3e64867ac9aa3cab95236e3eed520f601012#egg=ckanext_xloader
 ckantoolkit==0.0.7
 click==8.1.7
-cryptography==48.0.0
+cryptography==48.0.1
 defusedxml==0.7.1
 dominate==2.9.1
 elementpath==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ ckanext-envvars==0.0.6
 ckanext-pgsearch @ git+https://github.com/GSA/ckanext-pgsearch.git@48492c63fbaed8bcd892194b22192ffb404f2902
 ckanext-s3filestore @ git+https://github.com/keitaroinc/ckanext-s3filestore.git@e972ae3c36489dcfc716f75063ac64c13cde1146
 ckanext-saml2auth @ git+https://github.com/GSA/ckanext-saml2auth.git@062f26b19a525139bd613ef3654ca9dc64e0a096
-ckanext-usmetadata==0.3.3
+ckanext-usmetadata==0.3.4
 -e git+https://github.com/ckan/ckanext-xloader.git@11eb3e64867ac9aa3cab95236e3eed520f601012#egg=ckanext_xloader
 ckantoolkit==0.0.7
 click==8.1.7


### PR DESCRIPTION
https://github.com/GSA/ckanext-usmetadata/pull/77

after this ^ version is related, we can bump this version up