### PR TITLE
Update cloud-gov/cg-cli-tools to use main branch

### DIFF
--- a/.github/workflows/update_publishers.yml
+++ b/.github/workflows/update_publishers.yml
@@ -31,9 +31,7 @@ jobs:
           echo "UPDATE_PUBLISHERS=True" >> $GITHUB_ENV
       - name: Update Publishers
         if: ${{ env.UPDATE_PUBLISHERS }}
-        # pinned to cf7 until --wait is available for run-task on cf8...
-        # https://github.com/cloudfoundry/cli/issues/2238
-        uses: cloud-gov/cg-cli-tools@cli-v7
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             cf run-task inventory --command 'ckan dcat-usmetadata import-publishers config/data/inventory_publishers.csv' --wait --name 'update-publishers'
@@ -66,9 +64,7 @@ jobs:
           echo "UPDATE_PUBLISHERS=True" >> $GITHUB_ENV
       - name: Update Publishers
         if: ${{ env.UPDATE_PUBLISHERS }}
-        # pinned to cf7 until --wait is available for run-task on cf8...
-        # https://github.com/cloudfoundry/cli/issues/2238
-        uses: cloud-gov/cg-cli-tools@cli-v7
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             cf run-task inventory --command 'ckan dcat-usmetadata import-publishers config/data/inventory_publishers.csv' --wait --name 'update-publishers'

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ckanext-usmetadata==0.3.3
 -e git+https://github.com/ckan/ckanext-xloader.git@11eb3e64867ac9aa3cab95236e3eed520f601012#egg=ckanext_xloader
 ckantoolkit==0.0.7
 click==8.1.7
-cryptography==48.0.0
+cryptography==48.0.1
 defusedxml==0.7.1
 dominate==2.9.1
 elementpath==5.1.1


### PR DESCRIPTION
# Pull Request

This is because of [recent failures](https://github.com/GSA/inventory-app/actions/workflows/update_publishers.yml). Matches usage of other pipelines, see https://github.com/GSA/data.gov/blob/main/.github/workflows/deploy-template.yml#L80

## About

This has been failing for a while, not sure how long we've needed this.
If anyone wants to add failing step catch to create issue, go for it.

## PR TASKS

- [x] The actual code changes.
- [ ] ~Tests written and passed.~
- [x] Any changes to docs?
- [x] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
