### PR TITLE
6015 Cookie Hardening

### DIFF
--- a/config/ckan.ini
+++ b/config/ckan.ini
@@ -44,8 +44,9 @@ who.log_level = warning
 who.log_file = stdout
 # 15 minutes to match beaker.session.timeout
 who.timeout = 900
-# who.httponly = True # DEFAULT True already
+who.httponly = True
 who.secure = True
+who.samesite = Lax
 
 # secret for generating CSRF secure tokens
 WTF_CSRF_SECRET_KEY = $CKAN___WTF_CSRF_SECRET_KEY

--- a/e2e/cypress/integration/login.cy.js
+++ b/e2e/cypress/integration/login.cy.js
@@ -1,13 +1,23 @@
-describe('Login', () => {
-    
-    it('Invalid user login attempt', () => {
-        cy.login('not-user', 'not-password', true)
-        cy.contains('Login failed.')
+describe("Login", () => {
+  it("Invalid user login attempt", () => {
+    cy.login("not-user", "not-password", true);
+    cy.contains("Login failed.");
+  });
+
+  it("Valid login attempt", () => {
+    cy.login();
+    cy.get(".nav-tabs>li>a").should("contain", "My Organizations");
+  });
+
+  it("Auth cookie has secure attributes", () => {
+    cy.login();
+    cy.getCookie("ckan").should((cookie) => {
+      expect(cookie).to.exist;
+      expect(cookie.httpOnly).to.be.true;
+      // Secure flag only applies over HTTPS; in CI/local HTTP environments it will be false
+      // In production with HTTPS and nginx proxy, it will be true
+      // expect(cookie.secure).to.be.true;
+      expect(cookie.sameSite).to.eq("lax");
     });
-
-    it('Valid login attempt', () => {
-        cy.login()
-        cy.get('.nav-tabs>li>a').should('contain', 'My Organizations')
-    })
-
-})
+  });
+});

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -57,6 +57,10 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_hide_header Strict-Transport-Security;
+
+      # Enforce cookie security attributes on all cookies
+      proxy_cookie_flags ~ secure httponly samesite=lax;
+
       # proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with
       # redirects, we set the Host: header above already.


### PR DESCRIPTION
Addresses findings documented in [6015](https://github.com/GSA/data.gov/issues/6015).

Adds explicit cookie security attributes to meet compliance requirements and close recurring vulnerability scan findings.
  - **config/ckan.ini** - Explicitly set `HttpOnly=True` and `SameSite=Lax` for authentication cookies (repoze.who configuration)
  - **proxy/nginx.conf** - Add `proxy_cookie_flags` directive to enforce security attributes on all cookies at the proxy layer as a fallback