### PR TITLE
Update .snyk to ignore setuptools version

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,6 +4,13 @@ language-settings:
   python: "3.10"
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-PYTHON-SETUPTOOLS-17895075:
+    - "*":
+        reason: >-
+          GH issue created to track it
+          https://github.com/GSA/data.gov/issues/6167
+        expires: 2026-10-08T00:00:00.000Z
+        created: 2026-07-13T00:00:00.000Z
   SNYK-PYTHON-BLEACH-17356127:
     - "*":
         reason: >-


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/6167

## About

Ignore setuptools vulnerability for now

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
[requirements versions](https://github.com/GSA/inventory-app/blob/main/requirements.in.txt)
to pull in?
