### PR TITLE
pytest 9.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY requirements.txt requirements-dev.txt ${APP_DIR}/
 ADD setup.py README.md ${APP_DIR}/
 ADD ckanext ${APP_DIR}/ckanext/
 
+WORKDIR ${APP_DIR}
 RUN pip3 install --ignore-installed -r ${APP_DIR}/requirements.txt -r ${APP_DIR}/requirements-dev.txt
 # COPY docker-entrypoint.d/* /docker-entrypoint.d/
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
--e /app
+-e .
 
 flake8
-pytest==8.3.5
+pytest==9.0.3
 pytest-ckan
 pytest-cov
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ flake8
 pytest==9.0.3
 pytest-ckan
 pytest-cov
+pytest-factoryboy==2.8.1
 
 beautifulsoup4==4.5.1
 coveralls   #Let Unpinned - Requires latest coveralls


### PR DESCRIPTION
Fixes
- https://github.com/GSA/inventory-app/security/dependabot/111
  - pytest < 9.0.3 is vulnerable
  - dependabot couldn't fetch `-e /app`
  
Changes:
- update  pytest to 9.0.3
- set `-e .` to let dependabot resolve the local package
