### PR TITLE
5433: Inventory dataset form: can't change resource type

### DIFF
--- a/ckanext/datagov_inventory/templates/package/snippets/resource_form.html
+++ b/ckanext/datagov_inventory/templates/package/snippets/resource_form.html
@@ -14,7 +14,7 @@
                     {% if data.resource_type =='api' %} checked="checked" {% endif %} value="api"/>
             <label class="radio inline" for="field-resource-type-api">{{ _('Link to an API') }}</label>
             <input id="field-resource-type-accessurl" type="radio" name="resource_type"
-                    {% if not data.resource_type or data.resource_type =='' %} checked="checked" {% endif %} value=""/>
+                    {% if not data.resource_type or data.resource_type =='' or data.resource_type =='accessurl' %} checked="checked" {% endif %} value="accessurl"/>
             <label class="radio inline" for="field-resource-type-accessurl">{{ _('Access URL') }}</label>
         </div>
     </div>

--- a/ckanext/datagov_inventory/templates/package/snippets/resource_form.html
+++ b/ckanext/datagov_inventory/templates/package/snippets/resource_form.html
@@ -1,0 +1,88 @@
+{% ckan_extends %}
+
+{% block basic_fields_url %}
+    <p>Disclaimer: Uploading any file will automatically make this dataset public.</p>
+    {% set is_upload = (data.url_type == 'upload') %}
+    <div style="display: block">
+        <label style="padding-top:0" class="control-label">Resource</label>
+
+        <div class="controls"{% if allow_upload %} data-module="resource-upload-field"{% endif %}>
+            <input id="field-resource-type-file" type="radio" name="resource_type"
+                    {% if data.resource_type =='file' %} checked="checked" {% endif %} value="file"/>
+            <label class="radio inline" for="field-resource-type-file">{{ _('Data file') }}</label>
+            <input id="field-resource-type-api" type="radio" name="resource_type"
+                    {% if data.resource_type =='api' %} checked="checked" {% endif %} value="api"/>
+            <label class="radio inline" for="field-resource-type-api">{{ _('Link to an API') }}</label>
+            <input id="field-resource-type-accessurl" type="radio" name="resource_type"
+                    {% if not data.resource_type or data.resource_type =='' %} checked="checked" {% endif %} value=""/>
+            <label class="radio inline" for="field-resource-type-accessurl">{{ _('Access URL') }}</label>
+        </div>
+    </div>
+    <br/>
+
+    <div class="image-upload" is-upload="{% if is_upload %}true{% endif %}" data-module="image-upload"
+         data-module-is_url="{{ 'true' }}"
+         data-module-field_url="url" data-module-field_upload="upload" data-module-field_clear="clear_upload"
+         data-module-upload_label="{{ _('File') }}">
+
+        {{ form.input('url', label=_('URL'), id='field-image-url', placeholder=_('eg. http://example.com/gold-prices-jan-2011.json'),
+                value=data.url, error=errors.get('url'), classes=['exempt-allowed', 'control-full', 'resource-url'], is_required=true) }}
+
+        {{ form.input('upload', label=_('File'), id='field-image-upload', type='file', placeholder='', value='', error='', classes=['control-full','resource-upload']) }}
+        {% if is_upload %}
+            {{ form.checkbox('clear_upload', label=_('Clear Upload'), id='field-clear-upload', value='true', error='', classes=['control-full']) }}
+        {% endif %}
+
+    </div>
+
+{% endblock %}
+
+{% block basic_fields_name %}
+
+    {{ form.input('name', id='field-name', label=_('Name'), placeholder=_('e.g. January 2011 Gold Prices'),
+            value=data.name, error=errors.name, classes=['exempt-allowed', 'control-full']) }}
+
+{% endblock %}
+
+{% block basic_fields_format %}
+    {% set format_attrs = {'data-module': 'autocomplete', 'data-module-source': '/api/2/util/resource/media_autocomplete?incomplete=?'} %}
+
+    {% call form.input('format', id='field-format', label=_('Media Type'), placeholder=_('e.g. text/csv, application/xml, or application/json'),value=data.format, error=errors.format, classes=['exempt-allowed','control-medium'], attrs=format_attrs, is_required=false) %}
+    {% endcall %}
+
+    {% call form.input('formatReadable', id='field-format-readable', label=_('Format'), placeholder=_('e.g. csv, xml, json'),
+        value=data.formatReadable, error=errors.formatReadable, classes=['exempt-allowed', 'control-medium'],
+        is_required=false) %}
+    {% endcall %}
+
+    {{ form.input('describedBy', id='field-describedBy', label=_('Data Dictionary'), placeholder=_('http://www.agency.gov/widgets/schema.json'),
+            value=data.describedBy, error=errors.describedBy, classes=['exempt-allowed', 'control-medium'], is_required=false) }}
+
+    {% call form.input('describedByType', id='field-describedByType', label=_('Data Dictionary Type'), placeholder=_('e.g. text/csv, application/xml, or application/json'),
+        value=data.describedByType, error=errors.describedByType, classes=['exempt-allowed', 'control-medium'],
+        attrs=format_attrs,
+        is_required=false) %}
+    {% endcall %}
+
+    {{ form.input('conformsTo', id='field-conformsTo', label=_('Conforms To (Data Standard)'), placeholder=_('http://www.agency.gov/widget-data-standard/'),
+            value=data.conformsTo, error=errors.conformsTo, classes=['exempt-allowed', 'control-medium'], is_required=false) }}
+
+    <script type="text/javascript">
+        var redacted_json_raw = {
+            {% for field in data %}{% if 'redacted_' in field %}
+            '{{ field }}': '{{ data[field] }}',
+            {% endif %}{% endfor %}
+            'empty': 'value'
+        };
+    </script>
+
+{% endblock %}
+
+{% block basic_fields_name_2 %}
+
+{% endblock %}
+
+{% block save_button %}
+    <button class="btn btn-primary" name="save" value="go-metadata" type="submit">
+        {% block save_button_text %}{{ _('Finish') }}{% endblock %}</button>
+{% endblock %}

--- a/ckanext/datagov_inventory/tests/test_resource_type.py
+++ b/ckanext/datagov_inventory/tests/test_resource_type.py
@@ -8,7 +8,8 @@ import ckan.tests.helpers as helpers
 class TestResourceTypePersistence:
 
     def test_resource_type_api_persists(self):
-        dataset = factories.Dataset()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
         resource = helpers.call_action(
             'resource_create',
             package_id=dataset['id'],
@@ -28,7 +29,8 @@ class TestResourceTypePersistence:
         assert updated['resource_type'] == 'api'
 
     def test_resource_type_file_persists(self):
-        dataset = factories.Dataset()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
         resource = helpers.call_action(
             'resource_create',
             package_id=dataset['id'],
@@ -48,7 +50,8 @@ class TestResourceTypePersistence:
         assert updated['resource_type'] == 'file'
 
     def test_resource_type_empty_string_persists(self):
-        dataset = factories.Dataset()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
         resource = helpers.call_action(
             'resource_create',
             package_id=dataset['id'],
@@ -68,7 +71,8 @@ class TestResourceTypePersistence:
         assert updated['resource_type'] == ''
 
     def test_resource_type_change_from_api_to_empty_persists(self):
-        dataset = factories.Dataset()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
         resource = helpers.call_action(
             'resource_create',
             package_id=dataset['id'],
@@ -91,7 +95,8 @@ class TestResourceTypePersistence:
         assert refetched['resource_type'] == ''
 
     def test_resource_type_change_from_file_to_api_persists(self):
-        dataset = factories.Dataset()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
         resource = helpers.call_action(
             'resource_create',
             package_id=dataset['id'],
@@ -112,14 +117,3 @@ class TestResourceTypePersistence:
 
         refetched = helpers.call_action('resource_show', id=resource['id'])
         assert refetched['resource_type'] == 'api'
-
-    def test_resource_type_invalid_value_rejected(self):
-        dataset = factories.Dataset()
-        with pytest.raises(Exception):
-            helpers.call_action(
-                'resource_create',
-                package_id=dataset['id'],
-                url='https://example.gov/portal',
-                name='Test Resource',
-                resource_type='accessurl'
-            )

--- a/ckanext/datagov_inventory/tests/test_resource_type.py
+++ b/ckanext/datagov_inventory/tests/test_resource_type.py
@@ -1,0 +1,125 @@
+import pytest
+import ckan.tests.factories as factories
+import ckan.tests.helpers as helpers
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'datagov_inventory datastore')
+@pytest.mark.usefixtures('clean_db', 'with_plugins')
+class TestResourceTypePersistence:
+
+    def test_resource_type_api_persists(self):
+        dataset = factories.Dataset()
+        resource = helpers.call_action(
+            'resource_create',
+            package_id=dataset['id'],
+            url='https://api.example.gov/data',
+            name='Test API',
+            resource_type='api'
+        )
+        assert resource['resource_type'] == 'api'
+
+        updated = helpers.call_action(
+            'resource_update',
+            id=resource['id'],
+            url='https://api.example.gov/data',
+            name='Test API',
+            resource_type='api'
+        )
+        assert updated['resource_type'] == 'api'
+
+    def test_resource_type_file_persists(self):
+        dataset = factories.Dataset()
+        resource = helpers.call_action(
+            'resource_create',
+            package_id=dataset['id'],
+            url='https://example.gov/data.csv',
+            name='Test File',
+            resource_type='file'
+        )
+        assert resource['resource_type'] == 'file'
+
+        updated = helpers.call_action(
+            'resource_update',
+            id=resource['id'],
+            url='https://example.gov/data.csv',
+            name='Test File',
+            resource_type='file'
+        )
+        assert updated['resource_type'] == 'file'
+
+    def test_resource_type_empty_string_persists(self):
+        dataset = factories.Dataset()
+        resource = helpers.call_action(
+            'resource_create',
+            package_id=dataset['id'],
+            url='https://example.gov/portal',
+            name='Test Access URL',
+            resource_type=''
+        )
+        assert resource['resource_type'] == ''
+
+        updated = helpers.call_action(
+            'resource_update',
+            id=resource['id'],
+            url='https://example.gov/portal',
+            name='Test Access URL',
+            resource_type=''
+        )
+        assert updated['resource_type'] == ''
+
+    def test_resource_type_change_from_api_to_empty_persists(self):
+        dataset = factories.Dataset()
+        resource = helpers.call_action(
+            'resource_create',
+            package_id=dataset['id'],
+            url='https://api.example.gov/data',
+            name='Test Resource',
+            resource_type='api'
+        )
+        assert resource['resource_type'] == 'api'
+
+        updated = helpers.call_action(
+            'resource_update',
+            id=resource['id'],
+            url='https://example.gov/portal',
+            name='Test Resource',
+            resource_type=''
+        )
+        assert updated['resource_type'] == ''
+
+        refetched = helpers.call_action('resource_show', id=resource['id'])
+        assert refetched['resource_type'] == ''
+
+    def test_resource_type_change_from_file_to_api_persists(self):
+        dataset = factories.Dataset()
+        resource = helpers.call_action(
+            'resource_create',
+            package_id=dataset['id'],
+            url='https://example.gov/data.csv',
+            name='Test Resource',
+            resource_type='file'
+        )
+        assert resource['resource_type'] == 'file'
+
+        updated = helpers.call_action(
+            'resource_update',
+            id=resource['id'],
+            url='https://api.example.gov/data',
+            name='Test Resource',
+            resource_type='api'
+        )
+        assert updated['resource_type'] == 'api'
+
+        refetched = helpers.call_action('resource_show', id=resource['id'])
+        assert refetched['resource_type'] == 'api'
+
+    def test_resource_type_invalid_value_rejected(self):
+        dataset = factories.Dataset()
+        with pytest.raises(Exception):
+            helpers.call_action(
+                'resource_create',
+                package_id=dataset['id'],
+                url='https://example.gov/portal',
+                name='Test Resource',
+                resource_type='accessurl'
+            )


### PR DESCRIPTION
Related to [Issue #5433](https://github.com/GSA/data.gov/issues/5433)

This PR is to fix a bug where editing the resource type for a dataset doesn't persist when that resource type changes. 
