### PR TITLE
6230 snyk finding directory traversal fix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -27,12 +27,6 @@ ignore:
           https://github.com/GSA/data.gov/issues/6123
         expires: 2026-10-01T00:00:00.000Z
         created: 2026-07-01T00:00:00.000Z
-  SNYK-PYTHON-PIP-18426311:
-    - "*":
-        reason: >-
-          Slated to deal with in October. Link to issue: https://github.com/GSA/data.gov/issues/6230
-        expires: 2026-10-31T00:00:00.000Z
-        created: 2026-08-12T00:00:00.000Z
 patch: {}
 # specify the directories or files to be excludeed from import:
 exclude:

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ packaging==24.1
 passlib==1.7.4
 pathspec==1.1.1
 pika==1.4.1
-pip==26.1.2
+pip==26.2
 polib==1.2.0
 psycopg2==2.9.11
 pycparser==3.0


### PR DESCRIPTION
PR for [Issue 6230](https://github.com/GSA/data.gov/issues/6230). Per the snyk suggestion upgrade pip to version 26.2 or higher. Was slated for October but we can handle now. 