### PR TITLE
clarify xloader-api-token

### DIFF
--- a/.profile
+++ b/.profile
@@ -79,8 +79,9 @@ is_missing_required_value() {
 beaker_secret=$(vcap_get_service secrets .credentials.CKAN___BEAKER__SESSION__SECRET)
 ckan_secret=$(vcap_get_service secrets .credentials.CKAN___SECRET_KEY)
 csrf_secret=$(vcap_get_service secrets .credentials.CKAN___WTF_CSRF_SECRET_KEY)
+xloader_api_token=$(vcap_get_service secrets .credentials.CKANEXT__XLOADER__API_TOKEN)
 
-for secret_name in beaker_secret ckan_secret csrf_secret; do
+for secret_name in beaker_secret ckan_secret csrf_secret xloader_api_token; do
   secret_value="${!secret_name}"
   if is_missing_required_value "$secret_value"; then
     echo "$secret_name is not found in secrets" >&2
@@ -91,6 +92,7 @@ done
 export CKAN___BEAKER__SESSION__SECRET=$beaker_secret
 export CKAN___SECRET_KEY=$ckan_secret
 export CKAN___WTF_CSRF_SECRET_KEY=$csrf_secret
+export CKANEXT__XLOADER__API_TOKEN=$xloader_api_token
 
 
 export CKAN___CACHE_DIR=${SHARED_DIR}/cache
@@ -119,7 +121,6 @@ export CKANEXT__S3FILESTORE__AWS_SECRET_ACCESS_KEY=$(vcap_get_service s3 .creden
 export CKANEXT__S3FILESTORE__AWS_BUCKET_NAME=$(vcap_get_service s3 .credentials.bucket)
 export CKANEXT__S3FILESTORE__AWS_STORAGE_PATH=datagov/inventory-next
 # xloader uses the same db as datastore
-export CKANEXT__XLOADER__API_TOKEN=$(vcap_get_service secrets .credentials.API_TOKEN)
 export CKANEXT__XLOADER__JOBS_DB__URI=$(vcap_get_service db .credentials.uri)
 export CKANEXT__XLOADER__JOBS_DB__URI=${CKANEXT__XLOADER__JOBS_DB__URI/postgres/postgresql}
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@ Ensure the inventory app can reach the Solr app:
 | CKAN___SECRET_KEY | Flask session signing secret used for CKAN security-sensitive tokens and cookie-based sessions | `python -c "import secrets; print(secrets.token_urlsafe(32))"` |
 | CKAN___BEAKER__SESSION__SECRET | Session secret for encrypting CKAN sessions | `pwgen -s 32 1` |
 | CKAN___WTF_CSRF_SECRET_KEY | CSRF secret for generating CSRF tokens | `pwgen -s 32 1` |
+| CKANEXT__XLOADER__API_TOKEN | CKAN API token used by XLoader for authenticated job callbacks | Generate for the XLoader service user in CKAN |
 | DS_RO_PASSWORD | Read-only password for the datastore user | Initially randomly generated |
 | NEW_RELIC_LICENSE_KEY | New Relic license key | New Relic account settings |
 | SAML2_PRIVATE_KEY | Base64 encoded SAML2 key matching the Login.gov certificate | Data.gov DevSecOps Google Drive |
 
 To update secrets:
 
-    cf update-user-provided-service ${app_name}-secrets -p "CKAN___SECRET_KEY, CKAN___BEAKER__SESSION__SECRET, CKAN___WTF_CSRF_SECRET_KEY, DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY, SAML2_PRIVATE_KEY"
+    cf update-user-provided-service ${app_name}-secrets -p "CKAN___SECRET_KEY, CKAN___BEAKER__SESSION__SECRET, CKAN___WTF_CSRF_SECRET_KEY, CKANEXT__XLOADER__API_TOKEN, DS_RO_PASSWORD, NEW_RELIC_LICENSE_KEY, SAML2_PRIVATE_KEY"
 
 ### CI configuration
 


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5804

## About
- rename cg secret `API_TOKEN` to more specific `CKANEXT__XLOADER__API_TOKEN`.
- make it required during app start up